### PR TITLE
Add command to create example data

### DIFF
--- a/src/clims/runner/__init__.py
+++ b/src/clims/runner/__init__.py
@@ -1,0 +1,2 @@
+
+from __future__ import absolute_import, print_function

--- a/src/clims/runner/commands/__init__.py
+++ b/src/clims/runner/commands/__init__.py
@@ -1,0 +1,2 @@
+
+from __future__ import absolute_import, print_function

--- a/src/clims/runner/commands/create_example_data.py
+++ b/src/clims/runner/commands/create_example_data.py
@@ -1,0 +1,18 @@
+
+from __future__ import absolute_import, print_function
+
+import click
+from sentry.runner.decorators import configuration
+
+
+@click.command()
+@configuration
+def createexampledata():
+    """
+    Create example data for clims
+    """
+
+    # Import models here because they need to be wrapped with a Django context to work.
+    # /JD 2019-05-27
+    from clims.models.user_task import UserTask
+    UserTask.objects.create(name="Test", organization_id=1, handler="somehandler")

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -65,6 +65,7 @@ list(
             'sentry.runner.commands.start.start', 'sentry.runner.commands.tsdb.tsdb',
             'sentry.runner.commands.upgrade.upgrade',
             'sentry.runner.commands.permissions.permissions',
+            'clims.runner.commands.create_example_data.createexampledata'
         )
     )
 )


### PR DESCRIPTION
This adds the scaffolding for a command that can add test data to the db. This should be useful for developers who want to populate the system with data to start working on.