### PR TITLE
Fix really slow tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,9 @@
 [tool:pytest]
 python_files = test*.py
-addopts = --tb=native -p no:doctest -p no:warnings
-norecursedirs = bin dist docs htmlcov script hooks node_modules .* {args}
+# Note that the database is reused on tests, so run `pytest --create-db` before running the tests
+# if your models have changed
+addopts = --reuse-db --tb=native -p no:doctest -p no:warnings -s
+norecursedirs = src/clims/legacy bin dist docs htmlcov script hooks node_modules .* {args}
 looponfailroots = src tests
 selenium_driver = chrome
 


### PR DESCRIPTION
The tests require the whole db to be setup. When we were using south
migrations it took much less time, not because the migrations took less
time, but there seems to have been some mechanism in place that didn't
require the entire db to be rebuilt.

This turns on reuse of the db. It can be rebuilt when required using
`pytest --create-db`.