### PR TITLE
Make the dev setup easier

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 [DRAFT: All documents describe how Common LIMS will work in release 1.0. Contact the core devs for details on the current roadmap.]
 
+# Developer getting started documention
+
+- [Development](development.md)
+
 # Foundations
 
 - [High level design](high-level-design.md)
@@ -14,3 +18,7 @@
 - [User tasks](ui-user-task.md) TODO
 - [Searching](ui-search.md) TODO
 - [Projects](ui-projects.md) TODO
+
+# Other documents
+
+- [Roadmap](roadmap.md) TODO

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,72 +9,62 @@ Development happens on gitlab.org/commonlims and will be moved to github.com/com
 ## Setup
 
 To set up your environment, do the following:
+
 - Download and install Conda from: https://conda.io/en/latest/miniconda.html
 - Download commonlims snpseq plugins from: https://github.com/Molmed/commonlims-snpseq
 
 Start required services:
+
 - postgres server (specific to your installation)
 - redis server (specific to your installation)
-- `~/.camunda/server/apache-tomcat-[VERSION]/bin/startup.sh`
 
 You may also need to create a postgres user that matches your Unix username:
+
 - `sudo -i -u postgres`
 - `psql template1 postgres -c 'CREATE USER "[your-unix-username]" SUPERUSER;'`
+- Go into `/etc/postgresql/9.6/main/pg_hba.conf` (replace your postgresql version as necessary) and add the following
+  line under the "local" section:
+
+```
+local   all             camunda                                 password
+local   all             clims                                   password
+```
+
+- Restart postgres with `sudo service postgresql restart`
 
 From the root of the 'commonlims' project, run:
+
 - `source devboot`
-- alt: `source devboot-conda`  # If you want to use conda instead of pyenv
+- alt: `source devboot-conda` # If you want to use conda instead of pyenv
 
 Then run:
+
+- `make setup-db-user`
+- Add the password to ~/.pgpassword (as in structed by the above command)
 - `make develop`
+- `lims createuser --email admin@localhost --password changeit --superuser --no-input`
+- `lims upgrade`
 
 From the root of the 'commonlims' project, run: `lims devserver --browser-reload`
 
-Sentry should be available at: http://localhost:8000/
+CommonLims should be available at: http://localhost:8000/
 Camunda should be available at: http://localhost:8080/camunda/app/cockpit
+
+The default login is, `admin@localhost` with the password: `changeit`, or as specified above.
 
 ## Subsequent runs
 
 After initial setup, do the following to start your environment:
-- Start postgres, redis and camunda services
+
 - Run `source devboot`
+- Run `lims init`
 - Run `lims devserver --browser-reload`
-
-# Roadmap
-
-## v0.1.0 - Core framework set up (DONE)
-
-* The main building blocks and core roadmap are in place
-
- * Main design
- * UI
- * Workflow engine
- * Plugin mechanism
- * Several use cases in early draft (authentication, authorization, groups, settings, feature management and more)
- * A large part of the workflows in SNP&SEQ were implemented as POC
-
-A large part of this was achieved so early by leveraging another open source system, https://sentry.io.
-
-## v0.1.0 - A basic use case implemented for SNP&SEQ (CURRENT)
-
-UI general:
-
-* Users can see all queued tasks and limit to only what they will be working on
-* Users can select samples to batch process and enter a per-batch workflow.
-* Users can enter a specific per-batch subprocess required for SNP&SEQ, fragment_analyzer.
-
-fragment_analyzer:
-
-* Users can position samples as required. This means that a transition graph is created to/from different containers (e.g. sample cont1@a1 => cont2@a1)
-* Implement the transition engine (see below for core design)
-* Generic UI for FA specific variables
-*
 
 # Adding models
 
-* Add or edit a model definition under ./src/clims/models/
-* Run `lims django makemigrations`
-* Run `lims upgrade`
+- Add or edit a model definition under ./src/clims/models/
+- Run `lims django makemigrations`
+- Run `lims upgrade`
 
 # Resetting the database
 
@@ -82,17 +72,17 @@ You can get a fresh install of your database by running: `make reset-db`
 
 ## Create a rest layer
 
-* Add an endpoint class, e.g. `SamplesEndpoint` in e.g. `sentry/api/endpoints/samples.py`
-* Add a details class, e.g. `SamplesDetailsEndpoint` in e.g. `sentry/api/endpoints/samples.py`
-* Register the route to these endpoints in `sentry/api/urls.py`
-* Create serializers for the domain objects in `sentry/api/serializers/models/samples.py`
+- Add an endpoint class, e.g. `SamplesEndpoint` in e.g. `sentry/api/endpoints/samples.py`
+- Add a details class, e.g. `SamplesDetailsEndpoint` in e.g. `sentry/api/endpoints/samples.py`
+- Register the route to these endpoints in `sentry/api/urls.py`
+- Create serializers for the domain objects in `sentry/api/serializers/models/samples.py`
 
 # Adding workflows
 
 (TODO: Add more details)
 
-* Modify your workflow in Camunda modeler
-* Run `lims upgrade`
+- Modify your workflow in Camunda modeler
+- Run `lims upgrade`
 
 # Frontend development
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,31 @@
+# Roadmap
+
+NOTE: This document is currently not up-to-date
+
+## v0.1.0 - Core framework set up (DONE)
+
+- The main building blocks and core roadmap are in place
+
+- Main design
+- UI
+- Workflow engine
+- Plugin mechanism
+- Several use cases in early draft (authentication, authorization, groups, settings, feature management and more)
+- A large part of the workflows in SNP&SEQ were implemented as POC
+
+A large part of this was achieved so early by leveraging another open source system, https://sentry.io.
+
+## v0.1.0 - A basic use case implemented for SNP&SEQ (CURRENT)
+
+UI general:
+
+- Users can see all queued tasks and limit to only what they will be working on
+- Users can select samples to batch process and enter a per-batch workflow.
+- Users can enter a specific per-batch subprocess required for SNP&SEQ, fragment_analyzer.
+
+fragment_analyzer:
+
+- Users can position samples as required. This means that a transition graph is created to/from different containers (e.g. sample cont1@a1 => cont2@a1)
+- Implement the transition engine (see below for core design)
+- Generic UI for FA specific variables
+-

--- a/middleware/camunda/db-install.sh
+++ b/middleware/camunda/db-install.sh
@@ -4,24 +4,37 @@ SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 SCRIPT=~/.camunda/sql/create/postgres_engine_7.11.0.sql
 
+# Check that the clims database is there, and it is possible to connect to it.
+pg_isready -d clims
+if [ $? -eq 0 ]; then
+  echo "The clims db appears to be accepting connections"
+else
+  echo "The clims db does not accept connections. Please make sure you can connect with your $USER, and try again."
+  exit 1
+fi
+
 echo 'Creating postgres role...'
 
-set +e
 psql -d clims -c "CREATE ROLE camunda"
-set -e
 
-random_pass=$(openssl rand -base64 32)
+# Check if it was possible to create the camunda role. If it was not
+# assume it was already there.
+if [ $? -eq 0 ]; then
+  random_pass=$(openssl rand -base64 32)
 
-psql -d clims -c "ALTER ROLE camunda WITH LOGIN ENCRYPTED PASSWORD '$random_pass'"
+  psql -d clims -c "ALTER ROLE camunda WITH LOGIN ENCRYPTED PASSWORD '$random_pass'"
 
-echo "Overwriting config files..."
-cp -f $SCRIPT_PATH/server.xml ~/.camunda/server/apache-tomcat-9.0.19/conf/server.xml
-perl -pi -e "s#\{\{ postgres_password \}\}#$random_pass#g" ~/.camunda/server/apache-tomcat-9.0.19/conf/server.xml
-
+  echo "Overwriting config files..."
+  cp -f $SCRIPT_PATH/server.xml ~/.camunda/server/apache-tomcat-9.0.19/conf/server.xml
+  perl -pi -e "s#\{\{ postgres_password \}\}#$random_pass#g" ~/.camunda/server/apache-tomcat-9.0.19/conf/server.xml
+else
+  echo "Camunda user (probably) already existed. Will not overwrite current config"
+fi
 
 if [ ! -f $SCRIPT ]; then
     echo "SQL files for Camunda where not found. Please execute middleware/camunda/setup.sh first"
     exit 1
 fi
 
+export PGPASSWORD=$(xmlstarlet sel -T -t -m '//Server/GlobalNamingResources/Resource/@password' -v '.' -n ~/.camunda/server/apache-tomcat-9.0.19/conf/server.xml)
 psql -U camunda -d clims -a -f $SCRIPT

--- a/src/sentry/data/config/clims.conf.py.default
+++ b/src/sentry/data/config/clims.conf.py.default
@@ -10,7 +10,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'sentry.db.postgres',
         'NAME': 'clims',
-        'USER': 'postgres',
+        'USER': 'clims',
         'PASSWORD': '',
         'HOST': '',
         'PORT': '',


### PR DESCRIPTION
This introduces new instructions for settting up the dev-env, including how to setup password login for the clims database. The default user for the database is `clims` now, and it uses a randomly generated password to log in.

It also fixes some things in the camunda db-install script to make it a bit more robust.