### PR TITLE
Fix url patterns in clims

### DIFF
--- a/src/clims/api/urls.py
+++ b/src/clims/api/urls.py
@@ -41,7 +41,7 @@ def fmt(s):
     return s
 
 
-urlpatterns = patterns(
+urlpatterns = patterns('',
     # Workflow
     url(r'^organizations/(?P<organization_slug>[^\/]+)/workflow/aggregate/task/$',
         UserTaskAggregateEndpoint.as_view(),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -205,6 +205,7 @@ from .endpoints.setup_wizard import SetupWizard
 urlpatterns = patterns(
     '',
 
+    # Commmon LIMS urls
     url(
         r'',
         include('clims.api.urls')


### PR DESCRIPTION
The first argument to the `patterns` function is a base prefix for all routes in that list that follows. Since that was missing the first route was missed.