### PR TITLE
253, pool domain object

### DIFF
--- a/src/clims/handlers.py
+++ b/src/clims/handlers.py
@@ -55,7 +55,7 @@ class SubstancesSubmissionHandler(Handler):
 
     unique_registration = True
 
-    def handle(file_obj):
+    def handle(self, file_obj):
         pass
 
 

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -324,7 +324,7 @@ class SubstanceBase(ExtensibleBase):
     WrappedVersion = SubstanceVersion
 
     def __init__(self, **kwargs):
-        self._cached_parents = self._fetch_parents(kwargs)
+        self._unsaved_parents = self._fetch_parents(kwargs)
         super(SubstanceBase, self).__init__(**kwargs)
 
     def _fetch_parents(self, kwargs):
@@ -377,15 +377,15 @@ class SubstanceBase(ExtensibleBase):
         return SubstanceAncestry(self)
 
     def _save_parents(self):
-        parents = [substance_base._wrapped_version for substance_base in self._cached_parents]
+        parents = [substance_base._wrapped_version for substance_base in self._unsaved_parents]
         self._archetype.parents.add(*parents)
-        self._archetype.depth = max([p.depth for p in self._cached_parents]) + 1
+        self._archetype.depth = max([p.depth for p in self._unsaved_parents]) + 1
         self._archetype.save()
 
     def _get_origins(self):
         origins = list()
-        if self._cached_parents:
-            for p in self._cached_parents:
+        if self._unsaved_parents:
+            for p in self._unsaved_parents:
                 for origin in p._archetype.origins.all():
                     origins.append(origin)
         else:
@@ -394,7 +394,7 @@ class SubstanceBase(ExtensibleBase):
 
     def _save_subclass_specifics(self, creating):
         if creating:
-            if self._cached_parents:
+            if self._unsaved_parents:
                 self._save_parents()
 
             # We want the origin point(s) to always be populated, also for the origins themselves, in

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -135,7 +135,6 @@ class SubstanceService(object):
             return self.substance_to_wrapper(model)
 
     def substance_version_to_wrapper(self, substance_version):
-        from clims.services import SubstanceBase
         from clims.services.extensible import ExtensibleTypeNotRegistered
 
         try:
@@ -143,11 +142,9 @@ class SubstanceService(object):
                 substance_version.archetype.extensible_type.name)
             return SpecificExtensibleType(_wrapped_version=substance_version, _app=self._app)
         except ExtensibleTypeNotRegistered:
-            # This is an unregistered instance. This can happen for example when we have
-            # an instance that used to be registered but the Python version has been removed
-            # or rename.
-            # We must use the base class to wrap it:
-            return SubstanceBase(_wrapped_version=substance_version, _unregistered=True)
+            raise ExtensibleTypeNotRegistered(
+                'Extensible type is not yet registered: {}'
+                .format(substance_version.substance.extensible_type.name))
 
     def substance_to_wrapper(self, substance, version=None):
         if version is not None:

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -143,9 +143,11 @@ class SubstanceService(object):
                 substance_version.archetype.extensible_type.name)
             return SpecificExtensibleType(_wrapped_version=substance_version, _app=self._app)
         except ExtensibleTypeNotRegistered:
-            raise ExtensibleTypeNotRegistered(
-                'Extensible type is not yet registered: {}'
-                .format(substance_version.substance.extensible_type.name))
+            # This is an unregistered instance. This can happen for example when we have
+            # an instance that used to be registered but the Python version has been removed
+            # or rename.
+            # We must use the base class to wrap it:
+            return SubstanceBase(_wrapped_version=substance_version, _unregistered=True)
 
     def substance_to_wrapper(self, substance, version=None):
         if version is not None:
@@ -331,7 +333,9 @@ class SubstanceBase(ExtensibleBase):
 
         if wrapped_version and parents:
             raise AssertionError(
-                'Substance cannot be initialized with both wrapped version and parents')
+                'A substance may either be instantiated from a wrapped version '
+                '(i.e. an already created object fetched from db), or '
+                'a new set of of parents. This call had both!')
 
         return parents
 

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -107,40 +107,39 @@ class TestSubstance(SubstanceTestCase):
         fresh_substance = Substance.objects.get(name=substance.name)
         do_asserts(self.app.substances.to_wrapper(fresh_substance))
 
-    @pytest.mark.now
-    def test_create_pool__from_two_aliquots__pool_origin_are_original_samples(self):
+    def test_create_combined_sample__from_two_childs__origins_of_combined_are_original_samples(self):
         # Arrange
         props = dict(preciousness='*o*', color='red')
         sample1 = self.create_gemstone(**props)
         sample2 = self.create_gemstone(**props)
-        aliquot1 = sample1.create_child()
-        aliquot2 = sample2.create_child()
+        child1 = sample1.create_child()
+        child2 = sample2.create_child()
 
         # Act
-        pool = GemstoneSample(
-            name='pool1', organization=self.organization,
-            parents=[aliquot1, aliquot2])
-        pool.save()
+        combined = GemstoneSample(
+            name='combined1', organization=self.organization,
+            parents=[child1, child2])
+        combined.save()
 
         # Assert
-        assert len(pool.origins) == 2
-        assert set(pool.origins) == {sample1.id, sample2.id}
+        assert len(combined.origins) == 2
+        assert set(combined.origins) == {sample1.id, sample2.id}
 
-    def test_set_property_for_pool__fetched_object_from_db_ok(self):
+    def test_set_property_for_combined_sample__fetched_object_from_db_ok(self):
         # Arrange
         props = dict(preciousness='*o*', color='red')
         substance1 = self.create_gemstone(**props)
         substance2 = self.create_gemstone(**props)
 
         # Act
-        pool = GemstoneSample(
-            name='pool1', organization=self.organization,
+        combined = GemstoneSample(
+            name='combined1', organization=self.organization,
             parents=[substance1, substance2])
-        pool.preciousness = 'xxx'
-        pool.save()
+        combined.preciousness = 'xxx'
+        combined.save()
 
         # Assert
-        fetched = self.app.substances.get(name='pool1')
+        fetched = self.app.substances.get(name='combined1')
 
         assert 'xxx' == fetched.preciousness
         assert 2 == len(fetched.parents)
@@ -155,15 +154,15 @@ class TestSubstance(SubstanceTestCase):
         substance2 = self.create_gemstone(**props)
 
         # Act
-        pool = GemstoneSample(
-            name='pool1', organization=self.organization,
+        combined = GemstoneSample(
+            name='combined1', organization=self.organization,
             parents=[substance1, substance2])
-        pool.save()
+        combined.save()
 
         # Assert
         assert substance1.depth == 4
         assert substance2.depth == 1
-        assert pool.depth == 5
+        assert combined.depth == 5
 
     def test_updating_properties_via_update_or_create_updates_version(self):
         props = dict(preciousness='*o*', color='red')


### PR DESCRIPTION
Purpose:
To be able to instantiate pools with SubstanceBase. Pools are instantiated by calls similar to

mypool = Pool(name='mypool', organization=myorg, parents=[sample1, sample2])

Implementation:
If SubstanceBase is initialized with parents, these are stored internally in a cache until save() is called. SubstacneBase objects instantiated from a fetched db object (_wrapped_version), the parents property comes along with the input wrapped version.

Comments:
I removed the ancestry thing from ExtensibleBase. I thought that the _archetype.origins initialization got too fragmented, it would happen in both ExtensibleBase and in SubstanceBase.

