### PR TITLE
Clims 247 handle none value in sub base

### DIFF
--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -327,3 +327,43 @@ class PropertyBag(object):
 
     def __setitem__(self, key, value):
         self.new_values[key] = value
+
+
+class IntField(ExtensibleBaseField):
+    def validate(self, prop_type, value):
+        self.validate_with_casting(value, int)
+
+    @property
+    def raw_type(self):
+        # NOTE: Implemented as a property as the constant we're using lies in the models and
+        # we can't load the models too soon. It would be nice to change this!
+        return ExtensiblePropertyType.INT
+
+
+class FloatField(ExtensibleBaseField):
+    def validate(self, prop_type, value):
+        self.validate_with_casting(value, float)
+
+    @property
+    def raw_type(self):
+        return ExtensiblePropertyType.FLOAT
+
+
+class TextField(ExtensibleBaseField):
+    def validate(self, prop_type, value):
+        if not isinstance(value, six.string_types):
+            raise ExtensibleTypeValidationError("Expected string")
+
+    @property
+    def raw_type(self):
+        return ExtensiblePropertyType.STRING
+
+
+class JsonField(ExtensibleBaseField):
+    def validate(self, prop_type, value):
+        import json
+        json.dumps(value)
+
+    @property
+    def raw_type(self):
+        return ExtensiblePropertyType.JSON

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -6,9 +6,8 @@ import logging
 from datetime import datetime
 
 from clims.models.substance import Substance, SubstanceVersion
-from clims.models.extensible import ExtensibleProperty, ExtensiblePropertyType
-from clims.services.extensible import (ExtensibleBase, ExtensibleBaseField,
-        ExtensibleTypeValidationError)
+from clims.models.extensible import ExtensibleProperty
+from clims.services.extensible import ExtensibleBase
 from django.db import transaction
 from django.db.models import QuerySet
 from uuid import uuid4
@@ -174,46 +173,6 @@ class SubstanceService(object):
         size = handler.demo_file.tell()
         handler.demo_file.seek(0)
         return handler.demo_file, handler.demo_file_name, size
-
-
-class IntField(ExtensibleBaseField):
-    def validate(self, prop_type, value):
-        self.validate_with_casting(value, int)
-
-    @property
-    def raw_type(self):
-        # NOTE: Implemented as a property as the constant we're using lies in the models and
-        # we can't load the models too soon. It would be nice to change this!
-        return ExtensiblePropertyType.INT
-
-
-class FloatField(ExtensibleBaseField):
-    def validate(self, prop_type, value):
-        self.validate_with_casting(value, float)
-
-    @property
-    def raw_type(self):
-        return ExtensiblePropertyType.FLOAT
-
-
-class TextField(ExtensibleBaseField):
-    def validate(self, prop_type, value):
-        if not isinstance(value, six.string_types):
-            raise ExtensibleTypeValidationError("Expected string")
-
-    @property
-    def raw_type(self):
-        return ExtensiblePropertyType.STRING
-
-
-class JsonField(ExtensibleBaseField):
-    def validate(self, prop_type, value):
-        import json
-        json.dumps(value)
-
-    @property
-    def raw_type(self):
-        return ExtensiblePropertyType.JSON
 
 
 class SubstanceAncestry(object):

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -176,23 +176,9 @@ class SubstanceService(object):
         return handler.demo_file, handler.demo_file_name, size
 
 
-def validate_with_casting(value, fn):
-    valid = True
-    try:
-        cast = fn(value)
-        if cast != value:
-            valid = False
-    except ValueError:
-        valid = False
-
-    if not valid:
-        raise ExtensibleTypeValidationError(
-            "Value can not be interpreted as '{}'".format(fn.__name__))
-
-
 class IntField(ExtensibleBaseField):
     def validate(self, prop_type, value):
-        validate_with_casting(value, int)
+        self.validate_with_casting(value, int)
 
     @property
     def raw_type(self):
@@ -203,7 +189,7 @@ class IntField(ExtensibleBaseField):
 
 class FloatField(ExtensibleBaseField):
     def validate(self, prop_type, value):
-        validate_with_casting(value, float)
+        self.validate_with_casting(value, float)
 
     @property
     def raw_type(self):

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -24,30 +24,59 @@ class SubstanceTestCase(TestCase):
 
 class SubstancePropertiesTestCase(TestCase):
 
+    class ExampleSample(SubstanceBase):
+        moxy = FloatField("moxy")
+        cool = FloatField("cool")
+        erudite = FloatField("erudite", nullable=False)
+
+    def setUp(self):
+        self.register_extensible(self.ExampleSample)
+
     def test_can_create_substance_with_properties(self):
-
-        class ExampleSample(SubstanceBase):
-            moxy = FloatField("moxy")
-            cool = FloatField("cool")
-            erudite = FloatField("erudite")
-
         moxy = random.randint(1, 100)
         cool = random.randint(1, 100)
         erudite = random.randint(1, 100)
 
-        self.register_extensible(ExampleSample)
         name = "sample-{}".format(random.randint(1, 1000000))
-        sample = ExampleSample(name=name,
-                               organization=self.organization,
-                               moxy=moxy,
-                               cool=cool,
-                               erudite=erudite)
+        sample = self.ExampleSample(name=name,
+                                    organization=self.organization,
+                                    moxy=moxy,
+                                    cool=cool,
+                                    erudite=erudite)
         sample.save()
 
         fetched_sample = self.app.substances.get(name=sample.name)
         fetched_sample.moxy == moxy
         fetched_sample.cool == cool
         fetched_sample.erudite == erudite
+
+    def test_can_create_substance_with_property_set_to_none(self):
+        name = "sample-{}".format(random.randint(1, 1000000))
+        cool = random.randint(1, 100)
+        erudite = random.randint(1, 100)
+
+        sample = self.ExampleSample(name=name,
+                                    organization=self.organization,
+                                    moxy=None,
+                                    cool=cool,
+                                    erudite=erudite)
+        sample.save()
+
+        fetched_sample = self.app.substances.get(name=sample.name)
+        fetched_sample.moxy is None
+        fetched_sample.cool == cool
+        fetched_sample.erudite == erudite
+
+    def test_cannot_create_substance_with_property_set_to_none_unless_nullable(self):
+        name = "sample-{}".format(random.randint(1, 1000000))
+        cool = random.randint(1, 100)
+
+        with pytest.raises(ExtensibleTypeValidationError):
+            self.ExampleSample(name=name,
+                               organization=self.organization,
+                               moxy=None,
+                               cool=cool,
+                               erudite=None)
 
 
 class TestSubstance(SubstanceTestCase):

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -47,9 +47,9 @@ class SubstancePropertiesTestCase(TestCase):
         sample.save()
 
         fetched_sample = self.app.substances.get(name=sample.name)
-        fetched_sample.moxy == moxy
-        fetched_sample.cool == cool
-        fetched_sample.erudite == erudite
+        assert fetched_sample.moxy == moxy
+        assert fetched_sample.cool == cool
+        assert fetched_sample.erudite == erudite
 
     def test_can_create_substance_with_property_set_to_none(self):
         name = "sample-{}".format(random.randint(1, 1000000))
@@ -64,9 +64,9 @@ class SubstancePropertiesTestCase(TestCase):
         sample.save()
 
         fetched_sample = self.app.substances.get(name=sample.name)
-        fetched_sample.moxy is None
-        fetched_sample.cool == cool
-        fetched_sample.erudite == erudite
+        assert fetched_sample.moxy is None
+        assert fetched_sample.cool == cool
+        assert fetched_sample.erudite == erudite
 
     def test_cannot_create_substance_with_property_set_to_none_unless_nullable(self):
         name = "sample-{}".format(random.randint(1, 1000000))

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -8,7 +8,8 @@ from sentry.testutils import TestCase
 
 from clims.models import Substance, SubstanceVersion
 from clims.services import ExtensibleTypeValidationError
-from clims.services.substance import SubstanceBase, FloatField
+from clims.services.substance import SubstanceBase
+from clims.services.extensible import FloatField
 
 from tests.fixtures.plugins.gemstones_inc.models import GemstoneSample
 from django.db import IntegrityError


### PR DESCRIPTION
This allows fields to be set to None (provided that they are nullable - which they are by default). I also moved the Field things into extensible, since it seemed more related to that than to substance.