### PR TITLE
260, Add option to read excel as read only

### DIFF
--- a/src/clims/models/file.py
+++ b/src/clims/models/file.py
@@ -14,7 +14,8 @@ class StructuredFileMixin(object):
 
     def as_excel(self, temp_file, read_only=True):
         """
-        Returns the file as an excel file
+        Returns the file as an excel file. The caller has the responsibility to
+        delete the temp file after usage!
         """
         with open(temp_file.name, 'wb') as f:
             for _, chunk in enumerate(self.file.getfile()):

--- a/src/clims/models/file.py
+++ b/src/clims/models/file.py
@@ -4,7 +4,6 @@ from django.db import models
 
 from sentry.db.models import FlexibleForeignKey, Model, sane_repr
 from openpyxl import load_workbook
-from tempfile import NamedTemporaryFile
 
 
 class StructuredFileMixin(object):
@@ -13,16 +12,15 @@ class StructuredFileMixin(object):
     without having to import requirements etc.
     """
 
-    def as_excel(self):
+    def as_excel(self, temp_file, read_only=True):
         """
         Returns the file as an excel file
         """
-        with NamedTemporaryFile(suffix='.xlsx') as tmp:
-            with open(tmp.name, 'wb') as f:
-                for _, chunk in enumerate(self.file.getfile()):
-                    f.write(chunk)
+        with open(temp_file.name, 'wb') as f:
+            for _, chunk in enumerate(self.file.getfile()):
+                f.write(chunk)
 
-            workbook = load_workbook(tmp.name, data_only=True)
+        workbook = load_workbook(temp_file.name, data_only=True, read_only=read_only)
 
         return workbook
 

--- a/tests/clims/services/test_substances.py
+++ b/tests/clims/services/test_substances.py
@@ -78,6 +78,14 @@ class TestGemstoneSampleSubmission(SubstanceTestCase):
 
 
 class MyHandler(SubstancesSubmissionHandler):
+    def __init__(self, context, app):
+        super(MyHandler, self).__init__(context, app)
+        from tempfile import NamedTemporaryFile
+        self.temp_file = NamedTemporaryFile(suffix='.xlsx', delete=False)
+
+    def __del__(self):
+        os.remove(self.temp_file.name)
+
     def handle(self, file_obj):
         csv = self._as_csv(file_obj)
         for line in csv:
@@ -91,7 +99,7 @@ class MyHandler(SubstancesSubmissionHandler):
         if file_obj.name.endswith('.csv'):
             csv = file_obj.as_csv()
         elif file_obj.name.endswith('.xlsx'):
-            workbook = file_obj.as_excel()
+            workbook = file_obj.as_excel(self.temp_file)
             csv = self._xlsx_to_csv(workbook)
         else:
             _, ext = os.path.splitext(file_obj.name)

--- a/tests/clims/services/test_substances.py
+++ b/tests/clims/services/test_substances.py
@@ -80,11 +80,6 @@ class TestGemstoneSampleSubmission(SubstanceTestCase):
 class MyHandler(SubstancesSubmissionHandler):
     def __init__(self, context, app):
         super(MyHandler, self).__init__(context, app)
-        from tempfile import NamedTemporaryFile
-        self.temp_file = NamedTemporaryFile(suffix='.xlsx', delete=False)
-
-    def __del__(self):
-        os.remove(self.temp_file.name)
 
     def handle(self, file_obj):
         csv = self._as_csv(file_obj)
@@ -99,8 +94,10 @@ class MyHandler(SubstancesSubmissionHandler):
         if file_obj.name.endswith('.csv'):
             csv = file_obj.as_csv()
         elif file_obj.name.endswith('.xlsx'):
-            workbook = file_obj.as_excel(self.temp_file)
-            csv = self._xlsx_to_csv(workbook)
+            from tempfile import NamedTemporaryFile
+            with NamedTemporaryFile(suffix='.xlsx') as temp_file:
+                workbook = file_obj.as_excel(temp_file)
+                csv = self._xlsx_to_csv(workbook)
         else:
             _, ext = os.path.splitext(file_obj.name)
             NotImplementedError('File type not recognized: {}'.format(ext))


### PR DESCRIPTION
Purpose:
Opening excel files in read only mode is a lot faster than ordinary mode. 

Implementation:
The NamedTemporyFile is moved from the as_excel() method to the outer context. Apparently, the temp file is needed when reading from the excel file later on. In normal mode, the temp file is not deleted outside the "with ..." context (I thought that it was deleted and worked anyway). In read only mode the file is deleted, and the script stopped working. 

Now, the temp file is created within the Handler class (see test), and removed in the destructor method. 