### PR TITLE
clims 263, Suggestion for handling temp files

### DIFF
--- a/src/clims/migrations/0001_initial.py
+++ b/src/clims/migrations/0001_initial.py
@@ -172,7 +172,6 @@ class Migration(migrations.Migration):
             options={
                 'db_table': 'clims_organizationfile',
             },
-            bases=(clims.models.file.StructuredFileMixin, models.Model),
         ),
         migrations.CreateModel(
             name='PluginRegistration',

--- a/src/clims/models/extensible.py
+++ b/src/clims/models/extensible.py
@@ -52,7 +52,7 @@ class ExtensibleType(Model):
     when running `lims upgrade`.
 
     These types are examples of those that will be extensible, meaning that they can
-    be customized by plugins. Currently the Substance is the only one that's implemented.
+    be customized by plugins.
 
     * Substance
     * Container

--- a/src/clims/models/file.py
+++ b/src/clims/models/file.py
@@ -1,9 +1,45 @@
 from __future__ import absolute_import
-
+import os
 from django.db import models
-
+from tempfile import NamedTemporaryFile
 from sentry.db.models import FlexibleForeignKey, Model, sane_repr
 from openpyxl import load_workbook
+
+
+class ExcelFileWrapper(object):
+    """
+    Wraps an organization file in order to produce an excel file.
+    This functionality is wrapped in its own class because excel handling
+    needs a temporary file that needs to be removed after usage.
+    """
+
+    def __init__(self, organization_file):
+        self.temp_file = None
+        self.organization_file = organization_file
+        self.name = organization_file.name
+
+    def __enter__(self):
+        self.temp_file = NamedTemporaryFile(suffix='.xlsx')
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        os.remove(self.temp_file.name)
+
+    def as_excel(self, read_only=True):
+        """
+        Returns the file as an excel file. The caller has the responsibility to
+        delete the temp file after usage!
+        """
+        with open(self.temp_file.name, 'wb') as f:
+            for _, chunk in enumerate(self.organization_file.file.getfile()):
+                f.write(chunk)
+
+        workbook = load_workbook(self.temp_file.name, data_only=True, read_only=read_only)
+
+        return workbook
+
+    def as_csv(self):
+        return self.organization_file.as_csv()
 
 
 class StructuredFileMixin(object):
@@ -11,19 +47,6 @@ class StructuredFileMixin(object):
     A helper mixin for allowing plugin developers to easily parse files to common formats
     without having to import requirements etc.
     """
-
-    def as_excel(self, temp_file, read_only=True):
-        """
-        Returns the file as an excel file. The caller has the responsibility to
-        delete the temp file after usage!
-        """
-        with open(temp_file.name, 'wb') as f:
-            for _, chunk in enumerate(self.file.getfile()):
-                f.write(chunk)
-
-        workbook = load_workbook(temp_file.name, data_only=True, read_only=read_only)
-
-        return workbook
 
     def as_xml(self):
         raise NotImplementedError()

--- a/src/clims/models/file.py
+++ b/src/clims/models/file.py
@@ -14,29 +14,29 @@ class MultiFormatFile(object):
     """
 
     def __init__(self, organization_file):
-        self.temp_file = None
-        self.organization_file = organization_file
         self.name = organization_file.name
-        self.temp_file_name = None  # for testing
+        self._temp_file = None
+        self._organization_file = organization_file
+        self._temp_file_name = None  # for testing
 
     def __enter__(self):
-        self.temp_file = NamedTemporaryFile(suffix='.xlsx')
-        self.temp_file_name = self.temp_file.name
+        self._temp_file = NamedTemporaryFile(suffix='.xlsx')
+        self._temp_file_name = self._temp_file.name
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        os.remove(self.temp_file.name)
+        os.remove(self._temp_file.name)
 
     def as_excel(self, read_only=True):
-        if self.temp_file is None:
+        if self._temp_file is None:
             raise AssertionError('MultiFormatFile must be initiated as a context manager '
                                  'in order to export excel files, e.g. '
                                  'with MultiFormatFile(org_file) as wrapped: ...')
-        with open(self.temp_file.name, 'wb') as f:
-            for _, chunk in enumerate(self.organization_file.file.getfile()):
+        with open(self._temp_file.name, 'wb') as f:
+            for _, chunk in enumerate(self._organization_file.file.getfile()):
                 f.write(chunk)
 
-        workbook = load_workbook(self.temp_file.name, data_only=True, read_only=read_only)
+        workbook = load_workbook(self._temp_file.name, data_only=True, read_only=read_only)
 
         return workbook
 
@@ -46,8 +46,8 @@ class MultiFormatFile(object):
     def as_csv(self):
         # TODO: Add @lru_cache to the method when ready
         from clims.services.file_service.csv import Csv
-        return Csv(self.organization_file.file.getfile(),
-                   file_name=self.organization_file.file.name)
+        return Csv(self._organization_file.file.getfile(),
+                   file_name=self._organization_file.file.name)
 
 
 class OrganizationFile(Model):

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -347,7 +347,9 @@ class SubstanceService(WrapperMixin, ExtensibleServiceAPIMixin, object):
 
         # Call handler synchronously and in the same DB transaction
         context = HandlerContext(organization=organization)
-        plugins.handle(SubstancesSubmissionHandler, context, True, org_file)
+        from clims.models.file import ExcelFileWrapper
+        with ExcelFileWrapper(org_file) as wrapped_org_file:
+            plugins.handle(SubstancesSubmissionHandler, context, True, wrapped_org_file)
 
         return org_file
 

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -347,8 +347,8 @@ class SubstanceService(WrapperMixin, ExtensibleServiceAPIMixin, object):
 
         # Call handler synchronously and in the same DB transaction
         context = HandlerContext(organization=organization)
-        from clims.models.file import ExcelFileWrapper
-        with ExcelFileWrapper(org_file) as wrapped_org_file:
+        from clims.models.file import MultiFormatFile
+        with MultiFormatFile(org_file) as wrapped_org_file:
             plugins.handle(SubstancesSubmissionHandler, context, True, wrapped_org_file)
 
         return org_file

--- a/tests/clims/models/test_file.py
+++ b/tests/clims/models/test_file.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+from sentry.testutils import TestCase
+import os
+from clims.models.file import MultiFormatFile
+
+
+class TestFile(TestCase):
+    def test_use_multi_format_file__as_context_manager__internal_temp_file_deleted_after_usage(self):
+        # Arrange
+        org_file = FakeOrgFile()
+
+        # Act
+        with MultiFormatFile(org_file) as wrapped:
+            temp_file_name = wrapped.temp_file_name
+            assert os.path.exists(temp_file_name)
+
+        # Assert
+        assert not os.path.exists(temp_file_name)
+
+    def test_use_multi_format_file__without_context_manager__no_internal_temp_file_created(self):
+        # Arrange
+        org_file = FakeOrgFile()
+
+        # Act
+        wrapped = MultiFormatFile(org_file)
+
+        # Assert
+        assert wrapped.temp_file is None
+        assert wrapped.temp_file_name is None
+
+
+class FakeOrgFile:
+    def __init__(self):
+        self.name = None

--- a/tests/clims/models/test_file.py
+++ b/tests/clims/models/test_file.py
@@ -11,7 +11,7 @@ class TestFile(TestCase):
 
         # Act
         with MultiFormatFile(org_file) as wrapped:
-            temp_file_name = wrapped.temp_file_name
+            temp_file_name = wrapped._temp_file_name
             assert os.path.exists(temp_file_name)
 
         # Assert
@@ -25,8 +25,8 @@ class TestFile(TestCase):
         wrapped = MultiFormatFile(org_file)
 
         # Assert
-        assert wrapped.temp_file is None
-        assert wrapped.temp_file_name is None
+        assert wrapped._temp_file is None
+        assert wrapped._temp_file_name is None
 
 
 class FakeOrgFile:

--- a/tests/clims/services/test_substances.py
+++ b/tests/clims/services/test_substances.py
@@ -99,10 +99,8 @@ class MyHandler(SubstancesSubmissionHandler):
         if file_obj.name.endswith('.csv'):
             csv = file_obj.as_csv()
         elif file_obj.name.endswith('.xlsx'):
-            from tempfile import NamedTemporaryFile
-            with NamedTemporaryFile(suffix='.xlsx') as temp_file:
-                workbook = file_obj.as_excel(temp_file)
-                csv = self._xlsx_to_csv(workbook)
+            workbook = file_obj.as_excel()
+            csv = self._xlsx_to_csv(workbook)
         else:
             _, ext = os.path.splitext(file_obj.name)
             NotImplementedError('File type not recognized: {}'.format(ext))

--- a/tests/clims/services/test_substances.py
+++ b/tests/clims/services/test_substances.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
+import pytest
 import os
 import tests
 from six import BytesIO, binary_type
 import StringIO
+import logging
 from tests.clims.models.test_substance import SubstanceTestCase
 from clims.models.substance import Substance
 from sentry.plugins import plugins
@@ -32,10 +34,13 @@ def csv_sample_submission_path():
 class TestGemstoneSampleSubmission(SubstanceTestCase):
     def setUp(self):
         self.gemstone_sample_type = self.register_gemstone_type()
+        logger = logging.getLogger('clims.files')
+        logger.setLevel(logging.CRITICAL)
 
         # TODO: It would be cleaner to have the plugins instance in the ApplicationService
         plugins.load_handler_implementation(SubstancesSubmissionHandler, MyHandler)
 
+    @pytest.mark.now
     def test_run_gemstone_sample_submission_handler__with_csv__6_samples_found_in_db(self):
         # Arrange
         content = read_binary_file(csv_sample_submission_path())


### PR DESCRIPTION
Purpose:
This is a sketch for handling temp files when reading from excel. 

Implementation:
OrganizationFile is here wrapped within ExcelFileWrapper in order to handle the temp file. ExcelParser (in snpseq) is then not to be a context manager any longer. The good thing about this implementation is that temp file is encapsulated within a single class, and the intended use for that class is as a context manager. 

Comments:
I find it awkward to make OrganizationFile a context manager (in order to get rid of the wrapper class). How about this call
        org_file = OrganizationFile.objects.create(
when org_file is a context manager?

I think it shouldn't be named ExcelBlabla. load_file() is so generic, and it looks strange with that name here. My suggestion is to call it something generic, and include implementation of as_csv.

Another thought:
we could instantiate ExcelFileWrapper within handler, when it's time to extract excel. Problem here though, I think it might be hard to find this wrapper for a plugin developer.