### PR TITLE
clims 265, fix navigation property between project and substance

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,10 +13,13 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 # I'm 99.9% sure there is a plugin for easily skipping based on patterns from a file
 # (or that it's supported in the core) but I didn't find it right away, so:
 
-with open(".skiptests") as f:
-    # Extra skips should be of the format <class_name>.<function_name>, as that
-    # is the format pytest reports by default in the failure report
-    extra_skips = {line.strip() for line in f.readlines()}
+if os.path.exists(".skiptests"):
+    with open(".skiptests") as f:
+        # Extra skips should be of the format <class_name>.<function_name>, as that
+        # is the format pytest reports by default in the failure report
+        extra_skips = {line.strip() for line in f.readlines()}
+else:
+    extra_skips = {}
 
 
 def pytest_configure(config):

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -131,8 +131,7 @@ class SubstanceBase(HasLocationMixin, WrapperMixin, ExtensibleBase):
 
     def __init__(self, **kwargs):
         self._check_parameters(kwargs)
-        self._unsaved_parents = kwargs.pop("parents", None)
-        self._unsaved_project = kwargs.pop('project', None)
+        self._unsaved_parents = kwargs.pop('parents', None)
         super(SubstanceBase, self).__init__(**kwargs)
         self._new_location = None
 
@@ -199,6 +198,7 @@ class SubstanceBase(HasLocationMixin, WrapperMixin, ExtensibleBase):
         parents = [substance_base._wrapped_version for substance_base in self._unsaved_parents]
         self._archetype.parents.add(*parents)
         self._archetype.depth = max([p.depth for p in self._unsaved_parents]) + 1
+        self._archetype.save()
 
     def _get_origins(self):
         origins = list()
@@ -214,11 +214,6 @@ class SubstanceBase(HasLocationMixin, WrapperMixin, ExtensibleBase):
         if creating:
             if self._unsaved_parents:
                 self._save_parents()
-
-            if self._unsaved_project:
-                self._archetype.project = self._unsaved_project._archetype
-
-            self._archetype.save()
 
             # We want the origin point(s) to always be populated, also for the origins themselves, in
             # which case it points to itself. This way we can find all related samples in one query.

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -130,24 +130,9 @@ class SubstanceBase(HasLocationMixin, WrapperMixin, ExtensibleBase):
     WrappedVersion = SubstanceVersion
 
     def __init__(self, **kwargs):
-        self._check_parameters(kwargs)
         self._unsaved_parents = kwargs.pop('parents', None)
         super(SubstanceBase, self).__init__(**kwargs)
         self._new_location = None
-
-    def _check_parameters(self, kwargs):
-        wrapped_version = kwargs.get("_wrapped_version", None)
-        name = kwargs.get('name', None)
-        organization = kwargs.get('organization', None)
-        parents = kwargs.get("parents", None)
-        project = kwargs.get('project', None)
-        has_specific_parameteres = name or organization or project or parents
-        if has_specific_parameteres and wrapped_version:
-            raise AssertionError(
-                'A substance may either be instantiated from a wrapped version '
-                '(i.e. an already created object fetched from db), or '
-                'a new set of specific parameters, like name, project and so forth. '
-                'This call has both!')
 
     def _to_wrapper(self, model):
         """

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -17,7 +17,6 @@ from clims.models.file import OrganizationFile
 from clims.handlers import SubstancesSubmissionHandler, HandlerContext
 from clims.services.wrapper import WrapperMixin
 from clims.services.extensible_service_api import ExtensibleServiceAPIMixin
-from clims.utils import lazyprop
 
 
 class NotFound(Exception):
@@ -185,15 +184,13 @@ class SubstanceBase(HasLocationMixin, WrapperMixin, ExtensibleBase):
         return [self._app.substances.to_wrapper(parent)
                 for parent in self._archetype.parents.all()]
 
-    @lazyprop
+    @property
     def project(self):
-        if self._unsaved_project:
-            project_model = self._unsaved_project._archetype
-        elif self._archetype.project:
-            project_model = self._archetype.project
-        else:
-            return None
-        return self._app.projects.to_wrapper(project_model)
+        return self._app.projects.to_wrapper(self._archetype.project)
+
+    @project.setter
+    def project(self, project):
+        self._archetype.project = project._archetype
 
     def to_ancestry(self):
         return SubstanceAncestry(self)

--- a/tests/clims/models/test_project.py
+++ b/tests/clims/models/test_project.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import
 
 import pytest
 from sentry.testutils import TestCase
-from clims.services import ProjectBase, SubstanceBase, FloatField, TextField, IntField
+from clims.services.project import ProjectBase
+from clims.services.substance import SubstanceBase
+from clims.services import FloatField, TextField, IntField
 from django.db import IntegrityError
 
 
@@ -39,6 +41,44 @@ class TestProject(TestCase):
         sample.pointiness = 10.0
         sample.save()
         assert sample.project.name == project.name
+
+    def test_project_type(self):
+        project = VampireFangStudyProject(name="project1", organization=self.organization)
+        project.save()
+        sample = VampireFangSample(name="sample1", organization=self.organization, project=project)
+        sample.pointiness = 10.0
+        sample.save()
+        assert isinstance(sample.project, VampireFangStudyProject)
+
+    @pytest.mark.skip('not implemented')
+    def test_save_two_samples__with_same_names_but_different_projects__ok(self):
+        project1 = VampireFangStudyProject(name="project1", organization=self.organization)
+        project1.save()
+        sample1 = VampireFangSample(name="sample1", organization=self.organization, project=project1)
+        sample1.pointiness = 10.0
+        sample1.save()
+
+        project2 = VampireFangStudyProject(name="project2", organization=self.organization)
+        project2.save()
+        sample1b = VampireFangSample(name="sample1", organization=self.organization, project=project2)
+        sample1b.pointiness = 10.0
+        sample1b.save()
+
+    def test_sample_is_not_initalized_with_project__project_on_sample_is_none(self):
+        sample1 = VampireFangSample(name="sample1", organization=self.organization)
+        sample1.pointiness = 10.0
+        sample1.save()
+        assert sample1.project is None
+
+    def test_create_and_save_sample__with_project_set__fetched_sample_from_db_has_project(self):
+        project = VampireFangStudyProject(name="project1", organization=self.organization)
+        project.save()
+        sample = VampireFangSample(name="sample1", organization=self.organization, project=project)
+        sample.pointiness = 10.0
+        sample.save()
+        fetched_sample = self.app.substances.get(name='sample1')
+        assert isinstance(fetched_sample.project, VampireFangStudyProject)
+        assert fetched_sample.project.name == project.name
 
 
 class VampireFangStudyProject(ProjectBase):


### PR DESCRIPTION
Purpose:
In order to initiate samples with a project when importing sample submission.

Implementation:
Change the project property on substance so that it take advantage of the foreign key for django-model base class for substance. 

https://github.com/commonlims/commonlims/blob/7b6232855db802626810e3a3fe640184e2f464f5/src/clims/models/substance.py#L31

Before, project was located in the property-bag, and thus declared as an extensible property. 

Comments:
I decorated project property with lazyprop, in order to avoid excessive round trips to db in plugins. 

Comment #2:
This call will not work:
project = GetProjectSomehow("myproject")
self.app.substances.get(project=project)
nor this
self.app.substances.get(project="myproject")
I think I write a ticket for it.