### PR TITLE
clims 266, add method to filter substances on basis of project

### DIFF
--- a/src/clims/services/container.py
+++ b/src/clims/services/container.py
@@ -5,6 +5,7 @@ import six
 from clims.services.extensible import ExtensibleBase
 from clims.models import Container, ContainerVersion
 from clims.services.wrapper import WrapperMixin
+from clims.services.extensible_service_api import ExtensibleServiceAPIMixin
 
 
 class IndexOutOfBounds(Exception):
@@ -240,7 +241,7 @@ class PlateBase(ContainerBase):
         return "\n".join(map(six.text_type, rows))
 
 
-class ContainerService(WrapperMixin, object):
+class ContainerService(WrapperMixin, ExtensibleServiceAPIMixin, object):
     _archetype_version_class = ContainerVersion
     _archetype_class = Container
     _archetype_base_class = ContainerBase
@@ -248,6 +249,5 @@ class ContainerService(WrapperMixin, object):
     def __init__(self, app):
         self._app = app
 
-    def get(self, name):
-        model = Container.objects.get(name=name)
-        return self.to_wrapper(model)
+    def get_by_name(self, name):
+        return self.get(name=name)

--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -364,9 +364,13 @@ class PropertyBag(object):
             new_value = self.new_values.get(key, None)
             if new_value:
                 return new_value
-            persisted_value = self.extensible_wrapper._wrapped_version.properties.get(
-                extensible_property_type__name=key)
-            return persisted_value.value
+
+            # properties.all() is used to leverage the .prefetch_related() call
+            # that is used when fetching the extensible
+            properties = self.extensible_wrapper._wrapped_version.properties.all()
+            value = next(prop.value for prop in properties if prop.extensible_property_type.name == key)
+
+            return value
         except ExtensibleProperty.DoesNotExist:
             return None
 

--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -357,7 +357,8 @@ class PropertyBag(object):
             except ExtensibleProperty.DoesNotExist:
                 create(key, value)
 
-        self.new_values.clear()
+        # Note, new_values retained after save. Alternative would be to fetch from db and
+        # re-initiate.
 
     def __getitem__(self, key):
         try:
@@ -365,9 +366,9 @@ class PropertyBag(object):
             if new_value:
                 return new_value
 
-            # properties.all() is used to leverage the .prefetch_related() call
+            # '.all_properties' is used to leverage the .prefetch_related() call
             # that is used when fetching the extensible
-            properties = self.extensible_wrapper._wrapped_version.properties.all()
+            properties = self.extensible_wrapper._wrapped_version.all_properties
             value = next(prop.value for prop in properties if prop.extensible_property_type.name == key)
 
             return value

--- a/src/clims/services/extensible_service_api.py
+++ b/src/clims/services/extensible_service_api.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from django.db.models import Prefetch
 
 
 class ExtensibleServiceAPIMixin(object):
@@ -33,15 +34,17 @@ class ExtensibleServiceAPIMixin(object):
 
     def filter(self, **kwargs):
         get_args = self._get_filter_arguments(**kwargs)
-        models = self._archetype_version_class.objects.\
-            prefetch_related('properties__extensible_property_type').\
+        models = self._archetype_version_class.objects.prefetch_related(
+            Prefetch('properties', to_attr='all_properties'),
+            Prefetch('all_properties__extensible_property_type')).\
             filter(**get_args)
         return [self.to_wrapper(m) for m in models]
 
     def get(self, **kwargs):
         get_args = self._get_filter_arguments(**kwargs)
-        model = self._archetype_version_class.objects.\
-            prefetch_related('properties__extensible_property_type').\
+        model = self._archetype_version_class.objects.prefetch_related(
+            Prefetch('properties', to_attr='all_properties'),
+            Prefetch('all_properties__extensible_property_type')).\
             get(**get_args)
         return self.to_wrapper(model)
 

--- a/src/clims/services/extensible_service_api.py
+++ b/src/clims/services/extensible_service_api.py
@@ -33,12 +33,16 @@ class ExtensibleServiceAPIMixin(object):
 
     def filter(self, **kwargs):
         get_args = self._get_filter_arguments(**kwargs)
-        models = self._archetype_version_class.objects.prefetch_related('properties').filter(**get_args)
+        models = self._archetype_version_class.objects.\
+            prefetch_related('properties__extensible_property_type').\
+            filter(**get_args)
         return [self.to_wrapper(m) for m in models]
 
     def get(self, **kwargs):
         get_args = self._get_filter_arguments(**kwargs)
-        model = self._archetype_version_class.objects.prefetch_related('properties').get(**get_args)
+        model = self._archetype_version_class.objects.\
+            prefetch_related('properties__extensible_property_type').\
+            get(**get_args)
         return self.to_wrapper(model)
 
     def _get_filter_arguments(self, **kwargs):

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -359,3 +359,11 @@ class SubstanceService(WrapperMixin, ExtensibleServiceAPIMixin, object):
         size = handler.demo_file.tell()
         handler.demo_file.seek(0)
         return handler.demo_file, handler.demo_file_name, size
+
+    def filter_by_project(self, project_name):
+        # TODO: add organization to the filter parameters
+        return self.filter(project_name=project_name)
+
+    def get_by_name(self, name):
+        # TODO: add organization to the filter parameters
+        return self.get(name=name)

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -131,6 +131,7 @@ class SubstanceBase(HasLocationMixin, WrapperMixin, ExtensibleBase):
 
     def __init__(self, **kwargs):
         self._unsaved_parents = kwargs.pop('parents', None)
+        self._unsaved_project = kwargs.pop('project', None)
         super(SubstanceBase, self).__init__(**kwargs)
         self._new_location = None
 
@@ -170,6 +171,8 @@ class SubstanceBase(HasLocationMixin, WrapperMixin, ExtensibleBase):
 
     @property
     def project(self):
+        if self._unsaved_project:
+            return self._unsaved_project
         return self._app.projects.to_wrapper(self._archetype.project)
 
     @project.setter
@@ -183,7 +186,6 @@ class SubstanceBase(HasLocationMixin, WrapperMixin, ExtensibleBase):
         parents = [substance_base._wrapped_version for substance_base in self._unsaved_parents]
         self._archetype.parents.add(*parents)
         self._archetype.depth = max([p.depth for p in self._unsaved_parents]) + 1
-        self._archetype.save()
 
     def _get_origins(self):
         origins = list()
@@ -199,6 +201,12 @@ class SubstanceBase(HasLocationMixin, WrapperMixin, ExtensibleBase):
         if creating:
             if self._unsaved_parents:
                 self._save_parents()
+
+            if self._unsaved_project:
+                self._archetype.project = self._unsaved_project._archetype
+                self._unsaved_project = None
+
+            self._archetype.save()
 
             # We want the origin point(s) to always be populated, also for the origins themselves, in
             # which case it points to itself. This way we can find all related samples in one query.

--- a/tests/clims/models/test_container.py
+++ b/tests/clims/models/test_container.py
@@ -39,8 +39,7 @@ class TestContainer(TestCase):
         container.comment = "test"
         container.save()
 
-        model = Container.objects.get(id=container.id)
-        container_fetched_again = self.app.containers.to_wrapper(model)
+        container_fetched_again = self.app.containers.get(id=container.id)
         assert container.comment == container_fetched_again.comment
 
     def test_can_add_sample(self):
@@ -110,7 +109,7 @@ class TestContainer(TestCase):
         container.save()
         assert container["A:1"].id == in_original_order[0].id
 
-        container_fresh = self.app.containers.get(container.name)
+        container_fresh = self.app.containers.get_by_name(container.name)
         assert container_fresh["A:1"].id == in_original_order[0].id
 
     def test_can_output_default_string_info(self):
@@ -125,7 +124,7 @@ class TestContainer(TestCase):
             container.append(sample)
         container.save()
 
-        container_fresh = self.app.containers.get(container.name)
+        container_fresh = self.app.containers.get_by_name(container.name)
         string_rep = container_fresh.to_string().split("\n")
         assert len(string_rep) == container.rows
 

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -229,8 +229,7 @@ class TestSubstance(SubstanceTestCase):
         original.payload = payload
         original.save()
 
-        fetched = Substance.objects.get(name=original.name)
-        fetched = self.app.substances.to_wrapper(fetched)
+        fetched = self.app.substances.get_by_name(original.name)
         assert fetched.payload == payload
 
     def test_can_get_all_substances(self):
@@ -318,6 +317,7 @@ class TestSubstance(SubstanceTestCase):
         versions = [(s.version, s.properties) for s in sample.iter_versions()]
         assert len(versions) == 2
 
+    @pytest.mark.now
     def test_fetch_property_after_instansiation__no_db_calls(self):
         # Arrange
         from django.db import connection
@@ -340,7 +340,6 @@ class TestSubstance(SubstanceTestCase):
         assert len(connection.queries) == 0
         settings.DEBUG = old_debug
 
-    @pytest.mark.now
     def test_fetch_non_existent_property__attribute_error(self):
         sample = self.create_gemstone(color='red')
         with pytest.raises(AttributeError):

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -300,7 +300,6 @@ class TestSubstance(SubstanceTestCase):
         with pytest.raises(ExtensibleTypeValidationError):
             sample.has_something = 'True'
 
-    @pytest.mark.now
     def test_assigning_int_to_bool_field_fails(self):
         sample = self.create_gemstone(color='red')
         with pytest.raises(ExtensibleTypeValidationError):
@@ -318,3 +317,31 @@ class TestSubstance(SubstanceTestCase):
 
         versions = [(s.version, s.properties) for s in sample.iter_versions()]
         assert len(versions) == 2
+
+    def test_fetch_property_after_instansiation__no_db_calls(self):
+        # Arrange
+        from django.db import connection
+        from django.db import reset_queries
+        from django.conf import settings
+        old_debug = settings.DEBUG
+        settings.DEBUG = True
+        sample = self.create_gemstone()
+        sample.color = 'red'
+        sample.save()
+
+        fetched_sample = self.app.substances.get(name=sample.name)
+        reset_queries()
+
+        # Act
+        color = fetched_sample.color
+
+        # Assert
+        assert color == 'red'
+        assert len(connection.queries) == 0
+        settings.DEBUG = old_debug
+
+    @pytest.mark.now
+    def test_fetch_non_existent_property__attribute_error(self):
+        sample = self.create_gemstone(color='red')
+        with pytest.raises(AttributeError):
+            sample.blurr

--- a/tests/clims/services/test_substances.py
+++ b/tests/clims/services/test_substances.py
@@ -8,8 +8,11 @@ import logging
 from tests.clims.models.test_substance import SubstanceTestCase
 from clims.models.substance import Substance
 from sentry.plugins import plugins
+from sentry.testutils import TestCase
 from clims.handlers import SubstancesSubmissionHandler
 from clims.services import Csv
+from clims.services.project import ProjectBase
+from clims.services.extensible import TextField
 from tests.fixtures.plugins.gemstones_inc.models import GemstoneSample
 
 
@@ -40,7 +43,6 @@ class TestGemstoneSampleSubmission(SubstanceTestCase):
         # TODO: It would be cleaner to have the plugins instance in the ApplicationService
         plugins.load_handler_implementation(SubstancesSubmissionHandler, MyHandler)
 
-    @pytest.mark.now
     def test_run_gemstone_sample_submission_handler__with_csv__6_samples_found_in_db(self):
         # Arrange
         content = read_binary_file(csv_sample_submission_path())
@@ -80,6 +82,58 @@ class TestGemstoneSampleSubmission(SubstanceTestCase):
             'sample-Frink-1693_3',
         ]
         assert set(expected_sample_names).issubset(set(all_sample_names))
+
+
+class TestSubstanceService(TestCase):
+    def setUp(self):
+        self.register_extensible(GemstoneProject)
+        self.register_extensible(GemstoneSample)
+
+    def test_get_substances_by_project__with_2_samples_in_project_and_1_outside__2_hits(self):
+        # Arrange
+        project1 = GemstoneProject(name='project1', organization=self.organization)
+        project1.save()
+        project2 = GemstoneProject(name='project2', organization=self.organization)
+        project2.save()
+        sample1 = GemstoneSample(name='sample1', organization=self.organization, project=project1)
+        sample1.save()
+        sample2 = GemstoneSample(name='sample2', organization=self.organization, project=project1)
+        sample2.save()
+        sample3 = GemstoneSample(name='sample3', organization=self.organization, project=project2)
+        sample3.save()
+
+        # Act
+        fetched_samples = self.app.substances.filter(project=project1)
+
+        # Assert
+        assert len(fetched_samples) == 2
+        assert {'sample1', 'sample2'} == set([s.name for s in fetched_samples])
+
+    @pytest.mark.now
+    def test_get_substances_by_project_name__with_2_samples_in_project_and_1_outside__2_hits(self):
+        # Arrange
+        project1 = GemstoneProject(name='project1', organization=self.organization)
+        project1.save()
+        project2 = GemstoneProject(name='project2', organization=self.organization)
+        project2.save()
+        sample1 = GemstoneSample(name='sample1', organization=self.organization, project=project1)
+        sample1.save()
+        sample2 = GemstoneSample(name='sample2', organization=self.organization, project=project1)
+        sample2.save()
+        sample3 = GemstoneSample(name='sample3', organization=self.organization, project=project2)
+        sample3.save()
+
+        # Act
+        fetched_samples = self.app.substances.filter_by_project(project_name=project1.name)
+
+        # Assert
+        assert len(fetched_samples) == 2
+        assert {'sample1', 'sample2'} == set([s.name for s in fetched_samples])
+
+
+class GemstoneProject(ProjectBase):
+    species = TextField("species")
+    country_of_sampling = TextField("country_of_sampling")
 
 
 class MyHandler(SubstancesSubmissionHandler):

--- a/tests/clims/services/test_substances.py
+++ b/tests/clims/services/test_substances.py
@@ -109,8 +109,7 @@ class TestSubstanceService(TestCase):
         assert len(fetched_samples) == 2
         assert {'sample1', 'sample2'} == set([s.name for s in fetched_samples])
 
-    @pytest.mark.now
-    def test_get_substances_by_project_name__with_2_samples_in_project_and_1_outside__2_hits(self):
+    def test_filter_substances_by_project_name__with_2_samples_in_project_and_1_outside__2_hits(self):
         # Arrange
         project1 = GemstoneProject(name='project1', organization=self.organization)
         project1.save()
@@ -129,6 +128,22 @@ class TestSubstanceService(TestCase):
         # Assert
         assert len(fetched_samples) == 2
         assert {'sample1', 'sample2'} == set([s.name for s in fetched_samples])
+
+    @pytest.mark.now
+    def test_filter_substance_by_project_name__with_only_1_sample__sample_property_works(self):
+        # Arrange
+        project1 = GemstoneProject(name='project1', organization=self.organization)
+        project1.save()
+        sample1 = GemstoneSample(name='sample1', organization=self.organization, project=project1)
+        sample1.color = 'red'
+        sample1.save()
+
+        # Act
+        fetched_samples = self.app.substances.filter_by_project(project_name=project1.name)
+
+        # Assert
+        assert len(fetched_samples) == 1
+        assert fetched_samples[0].color == 'red'
 
 
 class GemstoneProject(ProjectBase):


### PR DESCRIPTION
Purpose:
The method to filter substances on basis of project is added because of a supposed future need. In addition, the framework is extended by implementing the filter() method on extensibles. Properties for extensibles are fetched in a way to prevent redundant db calls. Introduce a new type of test that test number of db calls for an operation. 

Comments:
* I had problems to set the django DEBUG setting at setup time. That's why I set it in the test. 
* Perhaps the test for number of db calls should be set in a separate test suite? Right now there is only one though. 
