### PR TITLE
269 fix handling of latest version in extensible service api

### DIFF
--- a/src/clims/services/extensible_service_api.py
+++ b/src/clims/services/extensible_service_api.py
@@ -50,13 +50,16 @@ class ExtensibleServiceAPIMixin(object):
 
     def _get_filter_arguments(self, **kwargs):
         get_args = {}
-        if 'latest' not in get_args.keys():
-            get_args['latest'] = True
+        if 'latest' not in kwargs.keys():
+            kwargs['latest'] = True
+
         for key, value in kwargs.items():
             if key == 'project':
                 get_args['archetype__project__name'] = value.name
             elif key == 'project_name':
                 get_args['archetype__project__name'] = value
-            elif not key == 'latest':
+            elif key == 'latest':
+                get_args['{}'.format(key)] = value
+            else:
                 get_args['archetype__{}'.format(key)] = value
         return get_args

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -317,7 +317,6 @@ class TestSubstance(SubstanceTestCase):
         versions = [(s.version, s.properties) for s in sample.iter_versions()]
         assert len(versions) == 2
 
-    @pytest.mark.now
     def test_fetch_property_after_instansiation__no_db_calls(self):
         # Arrange
         from django.db import connection
@@ -344,3 +343,46 @@ class TestSubstance(SubstanceTestCase):
         sample = self.create_gemstone(color='red')
         with pytest.raises(AttributeError):
             sample.blurr
+
+    @pytest.mark.now
+    def test_get_substance__with_two_versions_and_latest_version_true__latest_version_fetched(self):
+        # Arrange
+        sample = self.create_gemstone()
+        sample.color = 'red'
+        sample.save()
+
+        # Act
+        fetched_sample = self.app.substances.get(name=sample.name, latest=True)
+
+        # Assert
+        assert fetched_sample.name == sample.name
+        assert sample.version == 2
+        assert fetched_sample.version == sample.version
+
+    def test_get_substance__with_two_versions_and_latest_omitted__latest_version_fetched(self):
+        # Arrange
+        sample = self.create_gemstone()
+        sample.color = 'red'
+        sample.save()
+
+        # Act
+        fetched_sample = self.app.substances.get(name=sample.name)
+
+        # Assert
+        assert fetched_sample.name == sample.name
+        assert sample.version == 2
+        assert fetched_sample.version == sample.version
+
+    def test_filter_substance__with_3_versions_and_latest_version_false__2_instances_fetched(self):
+        # Arrange
+        sample = self.create_gemstone()
+        sample.color = 'red'
+        sample.save()
+        sample.color = 'yellow'
+        sample.save()
+
+        # Act
+        fetched_samples = self.app.substances.filter(name=sample.name, latest=False)
+
+        # Assert
+        assert len(fetched_samples) == 2


### PR DESCRIPTION
Purpose:
Fix a bug when fetching substances. The bug was that the latest version was always fetched whether or not the user entered latest=False or not

Implementation details:
I added a few tests on the latest-handling for fetching substances. 

Comments:
In future, it is probable that there are two desired fetch modes:
1) fetch latest
2) fetch all version including the latest
Now, when latest=False, all version are fetched but the latest. 