### PR TITLE
Plugin manager searches for implementations recursively

### DIFF
--- a/src/sentry/plugins/base/manager.py
+++ b/src/sentry/plugins/base/manager.py
@@ -263,9 +263,8 @@ class PluginManager(InstanceManager):
                 return clz
             elif nbr_of_subclasses > 1:
                 raise MultipleHandlersNotAllowed(
-                    "Trying to register the handler '{}' as the unique implementation "
-                    "of '{}' but already have '{}' registered".format(
-                        impl, baseclass, impl_already_reg))
+                    "Found the implementations: {}, when trying " +
+                    "to register a unique handler.".format(",".join(sub_classes)))
             else:
                 # We only had a single subclass, recurse to see if that hs any subclasses
                 return find_unique_deepest_impl(sub_classes[0])

--- a/src/sentry/plugins/base/manager.py
+++ b/src/sentry/plugins/base/manager.py
@@ -29,11 +29,6 @@ logger = logging.getLogger('clims.plugins')
 class PluginManager(InstanceManager):
     def __init__(self, class_list=None, instances=True):
         super(PluginManager, self).__init__(class_list, instances)
-        # TODO I guess work batches should be removed from here?
-        #      That is just a left over from earlier days of development?
-        self.work_batches = list()
-        self.handlers_mapped_by_work_batch_type = dict()  # TODO: clean up names!
-
         self.handlers = dict()
         self.register_handler_baseclasses()
 
@@ -147,16 +142,8 @@ class PluginManager(InstanceManager):
                 continue
             yield plugin
 
-    def _register_work_batches(self, class_path):
-        pass
-
-    def all_work_batches(self):
-        return self.work_batches
-
     def add(self, class_path):
         super(PluginManager, self).add(class_path)
-
-        self._register_work_batches(class_path)
 
     def configurable_for_project(self, project, version=1):
         for plugin in self.all(version=version):
@@ -322,7 +309,3 @@ class PluginManager(InstanceManager):
             ret.append(instance)
             instance.handle(*args)
         return ret
-
-
-class WorkBatchRegistrationException(Exception):
-    pass


### PR DESCRIPTION
This should make the plugin manager search recursively for handlers - meaning that they don't all have to go in the `handler.py` file in the plugin anymore. Hopefully it also made the plugin manager code a little bit easier to follow, though I still think that we need more iterations on it to make sure it is easier to work with.