### PR TITLE
clims-289, Fix MultiFormatFile taking path as input

### DIFF
--- a/src/clims/models/file.py
+++ b/src/clims/models/file.py
@@ -7,79 +7,123 @@ from sentry.db.models import FlexibleForeignKey, Model, sane_repr
 from openpyxl import load_workbook
 
 
-class MultiFormatFileBase(object):
-
+class FileContextBase(object):
     @abstractmethod
-    def as_excel(self, read_only):
+    def initiate(self):
         pass
 
     @abstractmethod
-    def as_xml(self):
+    def cleanup(self):
         pass
 
+    @property
     @abstractmethod
-    def as_csv(self):
+    def file_path(self):
+        pass
+
+    @property
+    @abstractmethod
+    def file_name(self):
         pass
 
 
-class MultiFormatFileFromPath(MultiFormatFileBase):
+class OrganizationFileContext(FileContextBase):
+    def __init__(self, organization_file):
+        self._organization_file = organization_file
+        self._temp_file = None
+        self._temp_file_name = None  # for testing
+
+    def initiate(self):
+        self._temp_file = NamedTemporaryFile(suffix='.xlsx')
+        self._temp_file_name = self._temp_file.name
+
+        with open(self._temp_file.name, 'wb') as f:
+            for _, chunk in enumerate(self._organization_file.file.getfile()):
+                f.write(chunk)
+
+    def cleanup(self):
+        os.remove(self._temp_file.name)
+
+    @property
+    def file_path(self):
+        return self._temp_file.name
+
+    @property
+    def file_name(self):
+        return self._organization_file.name
+
+
+class HarddiskFileContext(FileContextBase):
     def __init__(self, file_path):
-        self.file_path = file_path
-        self.name = os.path.basename(file_path)
+        self._file_path = file_path
 
-    def as_excel(self, read_only):
-        return load_workbook(self.file_path, data_only=False, read_only=read_only)
+    def initiate(self):
+        pass
 
-    def as_xml(self):
-        raise NotImplementedError()
+    def cleanup(self):
+        pass
 
-    def as_csv(self):
-        from clims.services.file_service.csv import Csv
-        return Csv(self.file_path)
+    @property
+    def file_path(self):
+        return self._file_path
+
+    @property
+    def file_name(self):
+        return os.path.basename(self._file_path)
 
 
-class MultiFormatFile(MultiFormatFileBase):
+class MultiFormatFile(object):
     """
     Wraps an organization file in order to generate any file format from it.
     This functionality is wrapped in a separate class because excel handling
     needs a temporary file that needs to be removed after usage.
     """
 
-    def __init__(self, organization_file):
-        self.name = organization_file.name
-        self._temp_file = None
-        self._organization_file = organization_file
-        self._temp_file_name = None  # for testing
+    def __init__(self, file_context):
+        self.file_context = file_context
+        self.file_path = None
 
     def __enter__(self):
-        self._temp_file = NamedTemporaryFile(suffix='.xlsx')
-        self._temp_file_name = self._temp_file.name
+        self.file_context.initiate()
+        self.file_path = self.file_context.file_path
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        os.remove(self._temp_file.name)
+        self.file_context.cleanup()
+
+    @classmethod
+    def from_path(cls, file_path):
+        file_context = HarddiskFileContext(file_path)
+        return MultiFormatFile(file_context=file_context)
+
+    @classmethod
+    def from_organization_file(cls, organization_file):
+        file_context = OrganizationFileContext(organization_file)
+        return MultiFormatFile(file_context=file_context)
 
     def as_excel(self, read_only=True):
-        if self._temp_file is None:
-            raise AssertionError('MultiFormatFile must be initiated as a context manager '
-                                 'in order to export excel files, e.g. '
-                                 'with MultiFormatFile(org_file) as wrapped: ...')
-        with open(self._temp_file.name, 'wb') as f:
-            for _, chunk in enumerate(self._organization_file.file.getfile()):
-                f.write(chunk)
-
-        workbook = load_workbook(self._temp_file.name, data_only=False, read_only=read_only)
+        self._validate_file_path()
+        workbook = load_workbook(self.file_path, data_only=False, read_only=read_only)
 
         return workbook
+
+    @property
+    def name(self):
+        return self.file_context.file_name
 
     def as_xml(self):
         raise NotImplementedError()
 
     def as_csv(self):
-        # TODO: Add @lru_cache to the method when ready
+        self._validate_file_path()
         from clims.services.file_service.csv import Csv
-        return Csv(self._organization_file.file.getfile(),
-                   file_name=self._organization_file.file.name)
+        return Csv(self.file_path, file_name=self.file_context.file_name)
+
+    def _validate_file_path(self):
+        if self.file_path is None:
+            raise AssertionError('MultiFormatFile must be initiated as a context manager '
+                                 'in order to export excel files, e.g. '
+                                 'with MultiFormatFile(org_file) as wrapped: ...')
 
 
 class OrganizationFile(Model):

--- a/src/clims/models/file.py
+++ b/src/clims/models/file.py
@@ -91,13 +91,13 @@ class MultiFormatFile(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.file_context.cleanup()
 
-    @classmethod
-    def from_path(cls, file_path):
+    @staticmethod
+    def from_path(file_path):
         file_context = HarddiskFileContext(file_path)
         return MultiFormatFile(file_context=file_context)
 
-    @classmethod
-    def from_organization_file(cls, organization_file):
+    @staticmethod
+    def from_organization_file(organization_file):
         file_context = OrganizationFileContext(organization_file)
         return MultiFormatFile(file_context=file_context)
 

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -390,7 +390,7 @@ class SubstanceService(WrapperMixin, ExtensibleServiceAPIMixin, object):
         # Call handler synchronously and in the same DB transaction
         context = HandlerContext(organization=organization)
         from clims.models.file import MultiFormatFile
-        with MultiFormatFile(org_file) as wrapped_org_file:
+        with MultiFormatFile.from_organization_file(org_file) as wrapped_org_file:
             plugins.handle(SubstancesSubmissionHandler, context, True, wrapped_org_file)
 
         return org_file

--- a/tests/clims/models/test_file.py
+++ b/tests/clims/models/test_file.py
@@ -11,7 +11,7 @@ class TestFile(TestCase):
 
         # Act
         with MultiFormatFile.from_organization_file(org_file) as file:
-            temp_file_name = file.file_wrapper._temp_file_name
+            temp_file_name = file.file_context._temp_file_name
             assert os.path.exists(temp_file_name)
 
         # Assert
@@ -25,8 +25,8 @@ class TestFile(TestCase):
         file = MultiFormatFile.from_organization_file(org_file)
 
         # Assert
-        assert file.file_wrapper._temp_file is None
-        assert file.file_wrapper._temp_file_name is None
+        assert file.file_context._temp_file is None
+        assert file.file_context._temp_file_name is None
 
 
 class FakeOrgFile:

--- a/tests/clims/models/test_file.py
+++ b/tests/clims/models/test_file.py
@@ -10,8 +10,8 @@ class TestFile(TestCase):
         org_file = FakeOrgFile()
 
         # Act
-        with MultiFormatFile(org_file) as wrapped:
-            temp_file_name = wrapped._temp_file_name
+        with MultiFormatFile.from_organization_file(org_file) as file:
+            temp_file_name = file.file_wrapper._temp_file_name
             assert os.path.exists(temp_file_name)
 
         # Assert
@@ -22,13 +22,19 @@ class TestFile(TestCase):
         org_file = FakeOrgFile()
 
         # Act
-        wrapped = MultiFormatFile(org_file)
+        file = MultiFormatFile.from_organization_file(org_file)
 
         # Assert
-        assert wrapped._temp_file is None
-        assert wrapped._temp_file_name is None
+        assert file.file_wrapper._temp_file is None
+        assert file.file_wrapper._temp_file_name is None
 
 
 class FakeOrgFile:
     def __init__(self):
         self.name = None
+        self.file = FakeFile()
+
+
+class FakeFile:
+    def getfile(self):
+        return ' '


### PR DESCRIPTION
A similar class was defined within the sample sub validation module. I
wanted a more central place for it, since it now was used at two
locations.