### PR TITLE
clims 285, trigger sample submission validation from UI

### DIFF
--- a/src/clims/handlers.py
+++ b/src/clims/handlers.py
@@ -47,6 +47,18 @@ class Handler(object):
         self.context = context
 
 
+class SubstancesValidationHandler(Handler):
+    """
+    Executed when a user submits a batch of substances, e.g. a list of samples
+    in a project.
+    """
+
+    unique_registration = True
+
+    def handle(self, file_stream):
+        pass
+
+
 class SubstancesSubmissionHandler(Handler):
     """
     Executed when a user submits a batch of substances, e.g. a list of samples

--- a/src/clims/handlers.py
+++ b/src/clims/handlers.py
@@ -55,7 +55,7 @@ class SubstancesValidationHandler(Handler):
 
     unique_registration = True
 
-    def handle(self, file_stream):
+    def handle(self, multi_format_file):
         pass
 
 
@@ -67,7 +67,7 @@ class SubstancesSubmissionHandler(Handler):
 
     unique_registration = True
 
-    def handle(self, file_obj):
+    def handle(self, multi_format_file):
         pass
 
 

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -369,16 +369,19 @@ class SubstanceService(WrapperMixin, ExtensibleServiceAPIMixin, object):
 
         context = HandlerContext(organization=organization)
         with MultiFormatFile.from_file_stream(full_path, file_stream) as wrapped_stream:
-            plugins.handle(SubstancesValidationHandler, context, False, wrapped_stream)
+            plugins.handle(
+                SubstancesValidationHandler, context, required=False,
+                multi_format_file=wrapped_stream)
 
         logger = logging.getLogger('clims.files')
         logger.info('substance_batch_import.start')
 
         org_file = self._create_organization_file(file_stream, full_path, organization.id, logger)
 
-        # Call handler synchronously and in the same DB transaction
         with MultiFormatFile.from_organization_file(org_file) as wrapped_org_file:
-            plugins.handle(SubstancesSubmissionHandler, context, True, wrapped_org_file)
+            plugins.handle(
+                SubstancesSubmissionHandler, context, required=True,
+                multi_format_file=wrapped_org_file)
 
         return org_file
 

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -356,7 +356,7 @@ class SubstanceService(WrapperMixin, ExtensibleServiceAPIMixin, object):
             raise NotFound("Can't find file with id '{}'".format(file_id))
 
     @transaction.atomic
-    def load_file(self, organization, full_path, fileobj, add_timestamp=False):
+    def load_file(self, organization, full_path, file_stream, add_timestamp=False):
         # TODO: Decide what we want to happen here. Should the user be able to load files
         # with an identical name or not? Makes more sense to me that we inspect if samples
         # with the same name have been uploaded or not. So for now we add this timestamp to the name
@@ -366,9 +366,21 @@ class SubstanceService(WrapperMixin, ExtensibleServiceAPIMixin, object):
             full_path, ext = full_path.rsplit(".", 1)
             full_path = full_path + datetime.now().strftime("%m_%d_%Y%_H_%M_%S") + "." + ext
 
+        context = HandlerContext(organization=organization)
         logger = logging.getLogger('clims.files')
         logger.info('substance_batch_import.start')
 
+        org_file = self._create_organization_file(file_stream, full_path, organization.id, logger)
+        # Call handler synchronously and in the same DB transaction
+        with MultiFormatFile.from_organization_file(org_file) as wrapped_org_file:
+            plugins.handle(SubstancesSubmissionHandler, context, True, wrapped_org_file)
+
+        return org_file
+
+    def _create_organization_file(self, file_stream, full_path, organization_id, logger):
+        """
+        Uploads file to the server and wrap it in a organization file
+        """
         name = full_path.rsplit('/', 1)[-1]
         if FILENAME_RE.search(name):
             raise FileNameValidationError('File name must not contain special whitespace characters')
@@ -378,19 +390,13 @@ class SubstanceService(WrapperMixin, ExtensibleServiceAPIMixin, object):
             type='substance-batch-file',
             headers=list(),
         )
-        file_model.putfile(fileobj, logger=logger)
+        file_model.putfile(file_stream, logger=logger)
 
         org_file = OrganizationFile.objects.create(
-            organization_id=organization.id,
+            organization_id=organization_id,
             file=file_model,
             name=full_path,
         )
-
-        # Call handler synchronously and in the same DB transaction
-        context = HandlerContext(organization=organization)
-        with MultiFormatFile.from_organization_file(org_file) as wrapped_org_file:
-            plugins.handle(SubstancesSubmissionHandler, context, True, wrapped_org_file)
-
         return org_file
 
     def create_submission_demo(self, file_type):

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from clims.models.substance import Substance, SubstanceVersion
 from clims.models.extensible import ExtensibleProperty
 from clims.models.location import SubstanceLocation
+from clims.models.file import MultiFormatFile
 from clims.services.extensible import (ExtensibleBase, HasLocationMixin)
 from django.db import transaction
 from django.db.models import QuerySet
@@ -365,8 +366,6 @@ class SubstanceService(WrapperMixin, ExtensibleServiceAPIMixin, object):
             full_path, ext = full_path.rsplit(".", 1)
             full_path = full_path + datetime.now().strftime("%m_%d_%Y%_H_%M_%S") + "." + ext
 
-        from sentry.plugins import plugins
-        plugins.require_handler(SubstancesSubmissionHandler)
         logger = logging.getLogger('clims.files')
         logger.info('substance_batch_import.start')
 
@@ -389,7 +388,6 @@ class SubstanceService(WrapperMixin, ExtensibleServiceAPIMixin, object):
 
         # Call handler synchronously and in the same DB transaction
         context = HandlerContext(organization=organization)
-        from clims.models.file import MultiFormatFile
         with MultiFormatFile.from_organization_file(org_file) as wrapped_org_file:
             plugins.handle(SubstancesSubmissionHandler, context, True, wrapped_org_file)
 

--- a/src/sentry/plugins/base/manager.py
+++ b/src/sentry/plugins/base/manager.py
@@ -290,7 +290,7 @@ class PluginManager(InstanceManager):
         if count == 0:
             raise RequiredHandlerNotFound("No handler that implements '{}' found".format(cls))
 
-    def handle(self, cls, context, required, *args):
+    def handle(self, cls, context, required, *args, **kwargs):
         """
         Runs all handlers registered for cls in sequence. *args are sent to the handler as arguments.
 
@@ -307,5 +307,5 @@ class PluginManager(InstanceManager):
             from clims.services import ioc
             instance = handler(context, ioc.app)
             ret.append(instance)
-            instance.handle(*args)
+            instance.handle(*args, **kwargs)
         return ret

--- a/tests/clims/models/test_file.py
+++ b/tests/clims/models/test_file.py
@@ -28,6 +28,22 @@ class TestFile(TestCase):
         assert file.file_context._temp_file is None
         assert file.file_context._temp_file_name is None
 
+    def test_use_multi_format_file__with_file_stream_initiation__internal_temp_file_deleted(self):
+        # Arrange
+        contents = 'abc'
+        from six import BytesIO
+        file_stream = BytesIO(contents)
+
+        # Act
+        # file/path.txt represents a path on the client computer.
+        with MultiFormatFile.from_file_stream('file/path.txt', file_stream) as file:
+            temp_file_name = file.file_context._temp_file.name
+            assert os.path.exists(temp_file_name)
+            assert file.name == 'path.txt'
+            assert file.file_path != 'file/path.txt'  # file_path is the path to the temp file (on server)
+
+        assert not os.path.exists(temp_file_name)
+
 
 class FakeOrgFile:
     def __init__(self):

--- a/tests/clims/services/test_substances.py
+++ b/tests/clims/services/test_substances.py
@@ -155,8 +155,8 @@ class MyHandler(SubstancesSubmissionHandler):
     def __init__(self, context, app):
         super(MyHandler, self).__init__(context, app)
 
-    def handle(self, file_obj):
-        csv = self._as_csv(file_obj)
+    def handle(self, multi_format_file):
+        csv = self._as_csv(multi_format_file)
         for line in csv:
             name = line['Sample ID']
             sample = GemstoneSample(name=name, organization=self.context.organization)


### PR DESCRIPTION
Purpose:
Trigger sample submission validation from commonlims. 

Implementation: 
The new base class SubstancesValidationHandler is marked as an optional handler, and is called within the substances.load_file() method. Extend MultiFormatFile so that it can take a file stream as input. This is needed, since the file contents is provided by a http request (file path from client is of no use), and OrganizationFile saves contents to db, which we don't want before the validation has been performed. 