### PR TITLE
Clims 276 search for projects

### DIFF
--- a/src/clims/api/endpoints/project.py
+++ b/src/clims/api/endpoints/project.py
@@ -17,7 +17,7 @@ class ProjectEndpoint(OrganizationEndpoint):
     def get(self, request, organization):
         # TODO: Filter by the organization
         search = request.GET.get('search', None)
-        queryset = self.app.projects._search_qs(search)
+        queryset = self.app.projects._search_qs(search, search_key="project.name")
 
         # Temporarily sort by date
         queryset = queryset.order_by('-archetype__created_at')

--- a/src/clims/api/endpoints/project.py
+++ b/src/clims/api/endpoints/project.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework import status
+
+from sentry.api.base import DEFAULT_AUTHENTICATION
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.bases.organization import OrganizationEndpoint
+from clims.api.serializers.models.project import ProjectSerializer
+
+
+class ProjectEndpoint(OrganizationEndpoint):
+    authentication_classes = DEFAULT_AUTHENTICATION
+    permission_classes = (IsAuthenticated, )
+
+    def get(self, request, organization):
+        # TODO: Filter by the organization
+        search = request.GET.get('search', None)
+        queryset = self.app.projects._search_qs(search)
+
+        # Temporarily sort by date
+        queryset = queryset.order_by('-archetype__created_at')
+
+        def handle_results(qs):
+            ret = list()
+            # NOTE: This could be simplified substantially if we had a queryset that returned
+            # the wrapper object directly.
+            for entry in qs:
+                wrapper = self.app.projects.to_wrapper(entry)
+                json = ProjectSerializer(wrapper).data
+                ret.append(json)
+            return ret
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            paginator_cls=OffsetPaginator,
+            default_per_page=20,
+            on_results=lambda data: handle_results(data))
+
+    def post(self, request, organization):
+        # TODO: Add user info to all actions
+        validator = ProjectSerializer(data=request.data)
+        if not validator.is_valid():
+            return self.respond(validator.errors, status=400)
+
+        validated = validator.validated_data
+        project = self.app.extensibles.create(
+            validated['name'],
+            validated['type_full_name'],
+            organization,
+            validated.get('properties', None))
+        ret = {"id": project.id}
+
+        return Response(ret, status=status.HTTP_201_CREATED)

--- a/src/clims/api/endpoints/substance.py
+++ b/src/clims/api/endpoints/substance.py
@@ -17,7 +17,7 @@ class SubstanceEndpoint(OrganizationEndpoint):
     def get(self, request, organization):
         # TODO: Filter by the organization
         search = request.GET.get('search', None)
-        queryset = self.app.substances._search_qs(search)
+        queryset = self.app.substances._search_qs(search, search_key="sample.name")
 
         # Temporarily sort by date
         queryset = queryset.order_by('-archetype__created_at')

--- a/src/clims/api/serializers/models/project.py
+++ b/src/clims/api/serializers/models/project.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from clims.api.serializers.models.extensible_property import ExtensiblePropertySerializer
+
+from rest_framework import serializers
+from rest_framework.fields import DictField
+
+
+class ProjectSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    version = serializers.IntegerField(read_only=True)
+    name = serializers.CharField()
+    properties = DictField(child=ExtensiblePropertySerializer(read_only=True))
+    type_full_name = serializers.CharField()

--- a/src/clims/api/urls.py
+++ b/src/clims/api/urls.py
@@ -9,6 +9,8 @@ from .endpoints.work_batch import (WorkBatchEndpoint,
 from .endpoints.substance import SubstanceEndpoint
 from .endpoints.substance_details import SubstanceDetailsEndpoint
 
+from .endpoints.project import ProjectEndpoint
+
 from .endpoints.container import ContainerEndpoint
 from .endpoints.processes import ProcessesEndpoint, TaskGroupsEndpoint
 from .endpoints.process_definitions import ProcessDefinitionsEndpoint
@@ -66,6 +68,9 @@ urlpatterns = patterns('',
 
     url(r'^organizations/(?P<organization_slug>[^\/]+)/containers/$',
         ContainerEndpoint.as_view(), name='clims-api-0-containers'),
+
+    url(r'^organizations/(?P<organization_slug>[^\/]+)/projects/$',
+        ProjectEndpoint.as_view(), name='clims-api-0-projects'),
 
     url(
         fmt(r'^organizations/{org}/substances/files/$'),

--- a/src/clims/services/extensible_service_api.py
+++ b/src/clims/services/extensible_service_api.py
@@ -32,6 +32,35 @@ class ExtensibleServiceAPIMixin(object):
 
         return self._archetype_version_class.objects.filter(latest=True).prefetch_related('properties')
 
+    def _search_qs(self, query, search_key):
+        # TODO: We'll have the same api for projects and containers, but for now we'll keep this
+        # here for simplicity
+
+        # TODO: We will offload all search (and sorting) of substances (as well as other things)
+        # to elastic. For now we throw an error if the search isn't just 'project.name:'
+
+        # TODO: The api for searching will be elastic's, so we just have a super simple parsing
+        # for now:
+
+        if query is None:
+            return self._all_qs()
+
+        query = query.strip()
+        query = query.split(" ")
+        if len(query) > 1:
+            raise NotImplementedError("Complex queries are not yet supported")
+
+        query = query[0]
+        key, val = query.split(":")
+
+        if key == search_key:
+            # TODO: the search parameter indicates we're looking for a substance that's a sample
+            # so add a category or similar so it doesn't find other things that are in a container.
+            return self._archetype_version_class.objects.filter(
+                latest=True, name__icontains=val).prefetch_related('properties')
+        else:
+            raise NotImplementedError("The key {} is not implemented".format(key))
+
     def filter(self, **kwargs):
         get_args = self._get_filter_arguments(**kwargs)
         models = self._archetype_version_class.objects.prefetch_related(

--- a/src/clims/services/project.py
+++ b/src/clims/services/project.py
@@ -48,34 +48,3 @@ class ProjectService(WrapperMixin, ExtensibleServiceAPIMixin, object):
 
     def __init__(self, app):
         self._app = app
-
-    def _search_qs(self, query):
-        # TODO: We'll have the same api for projects and containers, but for now we'll keep this
-        # here for simplicity
-
-        # TODO: We will offload all search (and sorting) of substances (as well as other things)
-        # to elastic. For now we throw an error if the search isn't just 'project.name:'
-
-        # TODO: The api for searching will be elastic's, so we just have a super simple parsing
-        # for now:
-
-        if query is None:
-            return self._all_qs()
-
-        query = query.strip()
-        query = query.split(" ")
-        if len(query) > 1:
-            raise NotImplementedError("Complex queries are not yet supported")
-
-        query = query[0]
-        key, val = query.split(":")
-
-        if key == "project.name":
-            # TODO: the search parameter indicates we're looking for a substance that's a sample
-            # so add a category or similar so it doesn't find other things that are in a container.
-            return ProjectVersion.objects.filter(
-                latest=True, name__icontains=val).prefetch_related('properties')
-        elif key == "sample.type":
-            pass
-        else:
-            raise NotImplementedError("The key {} is not implemented".format(key))

--- a/src/clims/services/project.py
+++ b/src/clims/services/project.py
@@ -48,3 +48,34 @@ class ProjectService(WrapperMixin, ExtensibleServiceAPIMixin, object):
 
     def __init__(self, app):
         self._app = app
+
+    def _search_qs(self, query):
+        # TODO: We'll have the same api for projects and containers, but for now we'll keep this
+        # here for simplicity
+
+        # TODO: We will offload all search (and sorting) of substances (as well as other things)
+        # to elastic. For now we throw an error if the search isn't just 'project.name:'
+
+        # TODO: The api for searching will be elastic's, so we just have a super simple parsing
+        # for now:
+
+        if query is None:
+            return self._all_qs()
+
+        query = query.strip()
+        query = query.split(" ")
+        if len(query) > 1:
+            raise NotImplementedError("Complex queries are not yet supported")
+
+        query = query[0]
+        key, val = query.split(":")
+
+        if key == "project.name":
+            # TODO: the search parameter indicates we're looking for a substance that's a sample
+            # so add a category or similar so it doesn't find other things that are in a container.
+            return ProjectVersion.objects.filter(
+                latest=True, name__icontains=val).prefetch_related('properties')
+        elif key == "sample.type":
+            pass
+        else:
+            raise NotImplementedError("The key {} is not implemented".format(key))

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -313,38 +313,6 @@ class SubstanceService(WrapperMixin, ExtensibleServiceAPIMixin, object):
     def __init__(self, app):
         self._app = app
 
-    def _search_qs(self, query):
-        # TODO: We'll have the same api for projects and containers, but for now we'll keep this
-        # here for simplicity
-
-        # TODO: We will offload all search (and sorting) of substances (as well as other things)
-        # to elastic. For now we throw an error if the search isn't just 'sample.name:' or
-        # 'container.name:'
-
-        # TODO: The api for searching will be elastic's, so we just have a super simple parsing
-        # for now:
-
-        if query is None:
-            return self._all_qs()
-
-        query = query.strip()
-        query = query.split(" ")
-        if len(query) > 1:
-            raise NotImplementedError("Complex queries are not yet supported")
-
-        query = query[0]
-        key, val = query.split(":")
-
-        if key == "sample.name":
-            # TODO: the search parameter indicates we're looking for a substance that's a sample
-            # so add a category or similar so it doesn't find other things that are in a container.
-            return SubstanceVersion.objects.filter(
-                latest=True, name__icontains=val).prefetch_related('properties')
-        elif key == "sample.type":
-            pass
-        else:
-            raise NotImplementedError("The key {} is not implemented".format(key))
-
     def all_submission_files(self, organization):
         # TODO: Currently returns OrganizationFile. Need to filter it down to only substance files
         #       So add a "type" to the file.

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -752,7 +752,6 @@ class Fixtures(object):
         return ret
 
     def create_substance(self, klass, name=None, **kwargs):
-        # TODO: This shouldn't be necessary as there should be only one app instance per test
         properties = kwargs or dict()
         ret = self.register_extensible(klass)
 
@@ -762,7 +761,6 @@ class Fixtures(object):
         return ret
 
     def create_clims_project(self, klass, name=None, **kwargs):
-        # TODO: This shouldn't be necessary as there should be only one app instance per test
         properties = kwargs or dict()
         ret = self.register_extensible(klass)
 

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -761,6 +761,16 @@ class Fixtures(object):
         ret = self.app.extensibles.create(name, klass, self.organization, properties=properties)
         return ret
 
+    def create_clims_project(self, klass, name=None, **kwargs):
+        # TODO: This shouldn't be necessary as there should be only one app instance per test
+        properties = kwargs or dict()
+        ret = self.register_extensible(klass)
+
+        if not name:
+            name = "project-{}".format(uuid4())
+        ret = self.app.extensibles.create(name, klass, self.organization, properties=properties)
+        return ret
+
     def create_container(self, klass, name=None, prefix="container", **kwargs):
         properties = kwargs or dict()
         # TODO: Explicitly register only if required?

--- a/tests/clims/api/endpoints/test_projects.py
+++ b/tests/clims/api/endpoints/test_projects.py
@@ -1,0 +1,93 @@
+from __future__ import absolute_import
+
+import random
+import json
+
+from django.core.urlresolvers import reverse
+from clims.models.project import Project
+
+
+from sentry.testutils import APITestCase
+
+from rest_framework import status
+from tests.fixtures.plugins.gemstones_inc.models import GemstoneProject
+
+
+class ProjectTest(APITestCase):
+    def create_gemstone(self, *args, **kwargs):
+        return self.create_Project(GemstoneProject, *args, **kwargs)
+
+    def test_search_project_find_single_by_name(self):
+        # NOTE: For now, the search is always using wildcards. This will be ported to using
+        # elastic in milestone 2.
+        project = self.create_clims_project(GemstoneProject, continent='Eurasia')
+        project.save()
+
+        another = self.create_clims_project(GemstoneProject)
+        another.save()
+
+        search = 'project.name:' + project.name
+
+        url = reverse('clims-api-0-projects', args=(project.organization.name,))
+        self.login_as(self.user)
+        response = self.client.get(url + '?search=' + search)
+        assert response.status_code == 200, response.content
+        # The search is for a unique name, so this must be true:
+        assert len(response.data) == 1, len(response.data)
+
+    def test_get_project(self):
+        first = self.create_clims_project(GemstoneProject, continent='Eurasia')
+        first.save()
+
+        url = reverse('clims-api-0-projects', args=(first.organization.name,))
+        self.login_as(self.user)
+        response = self.client.get(url)
+        len_before = len(response.data)
+
+        second = self.create_clims_project(GemstoneProject)
+        response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+
+        assert len(response.data) == len_before + 1
+        data_by_id = {int(entry['id']): entry for entry in response.data}
+
+        def asserts(project, response):
+            properties = response.pop('properties')
+            if 'color' in properties:
+                assert properties['continent']['value'] == project.properties['continent'].value
+            assert response.pop('name') == project.name
+            assert response.pop('version') == project.version
+            assert response.pop('id') == project.id
+            assert response.pop('type_full_name') == project.type_full_name
+            assert len(response) == 0
+
+        asserts(first, data_by_id[first.id])
+        asserts(second, data_by_id[second.id])
+
+    def test_post_substance(self):
+        # Setup
+        extensible_type = self.register_extensible(GemstoneProject)
+
+        url = reverse('clims-api-0-projects', args=(extensible_type.plugin.organization.slug,))
+
+        payload = {
+            "name": "stuff:{}".format(random.random()),
+            "properties": {'continent': 'Africa'},
+            "type_full_name": extensible_type.name
+        }
+
+        # Test
+        self.login_as(self.user)
+        response = self.client.post(
+            path=url,
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+
+        # Validate
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        created_id = response.data["id"]
+
+        substance = Project.objects.get(id=created_id)
+        assert substance.name == payload['name']

--- a/tests/clims/api/endpoints/test_projects.py
+++ b/tests/clims/api/endpoints/test_projects.py
@@ -14,8 +14,6 @@ from tests.fixtures.plugins.gemstones_inc.models import GemstoneProject
 
 
 class ProjectTest(APITestCase):
-    def create_gemstone(self, *args, **kwargs):
-        return self.create_Project(GemstoneProject, *args, **kwargs)
 
     def test_search_project_find_single_by_name(self):
         # NOTE: For now, the search is always using wildcards. This will be ported to using

--- a/tests/fixtures/plugins/gemstones_inc/models.py
+++ b/tests/fixtures/plugins/gemstones_inc/models.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import
-from clims.services import SubstanceBase, TextField, IntField, FloatField, JsonField, BoolField
+from clims.services import SubstanceBase, ProjectBase, TextField, IntField, FloatField, JsonField, BoolField
 from clims.services import PlateBase
+
+
+class GemstoneProject(ProjectBase):
+    continent = TextField(prop_name="continent")
 
 
 class GemstoneSample(SubstanceBase):


### PR DESCRIPTION
This is a first version of the projects endpoint. It has the same "basic search" as the substance view. I also moved the search into the extensible service API to avoid duplicating the search code all over the place. However, I do imagine that in the relatively near future we will want to move all the search code into it's own search engine proxy class, or similar.

This new search endpoint has not yet been hooked up to the front-end. That will need to happen in a separate PR.