### PR TITLE
clims 282, Simplify property initalization

### DIFF
--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -136,10 +136,9 @@ class HasLocationMixin(object):
 
 
 class ExtensibleBaseField(object):
-    def __init__(self, prop_name=None, display_name=None, nullable=True):
-        # TODO: Create a metaclass for SubstanceBase that ensures prop_name is always set
-        self.prop_name = prop_name
-        self.display_name = display_name or prop_name
+    def __init__(self, display_name=None, nullable=True):
+        self.prop_name = None
+        self.display_name = display_name or None
         self.nullable = nullable
 
     def validate_with_casting(self, value, fn):
@@ -188,10 +187,13 @@ class PropertyInitiator(type):
         for k, v in iteritems(attributedict):
             if issubclass(type(v), ExtensibleBaseField):
                 v.prop_name = k
+                if v.display_name is None:
+                    v.display_name = k
         return type.__new__(cls, clsname, superclasses, attributedict)
 
 
 class ExtensibleBase(object):
+    # This syntax is changed in python 3!
     __metaclass__ = PropertyInitiator
 
     def __init__(self, **kwargs):
@@ -279,6 +281,13 @@ class ExtensibleBase(object):
         Returns the full name of this type
         """
         return "{}.{}".format(self.__class__.__module__, self.__class__.__name__)
+
+    @classmethod
+    def type_full_name_cls(cls):
+        """
+        Returns the full name of this type
+        """
+        return "{}.{}".format(cls.__module__, cls.__name__)
 
     @property
     def version(self):

--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -134,6 +134,53 @@ class HasLocationMixin(object):
             self._wrapped_version.archetype.save()
 
 
+class ExtensibleBaseField(object):
+    def __init__(self, prop_name=None, display_name=None, nullable=True):
+        # TODO: Create a metaclass for SubstanceBase that ensures prop_name is always set
+        self.prop_name = prop_name
+        self.display_name = display_name or prop_name
+        self.nullable = nullable
+
+    def validate_with_casting(self, value, fn):
+        valid = True
+        try:
+            cast = fn(value)
+            if cast != value:
+                valid = False
+        except ValueError:
+            valid = False
+
+        if not valid:
+            raise ExtensibleTypeValidationError(
+                "Value can not be interpreted as '{}'".format(fn.__name__))
+
+    def validate(self, prop_type, value):
+        # Override this in subclasses
+        pass
+
+    def _handle_validate(self, obj, value):
+        try:
+            prop_type = obj._archetype.extensible_type.property_types.get(name=self.prop_name)
+        except ExtensiblePropertyType.DoesNotExist:
+            raise FieldDoesNotExist(self.prop_name)
+
+        if value is None:
+            if self.nullable:
+                return
+            else:
+                raise ExtensibleTypeValidationError("None was not a valid value for Field: {}, if you want to "
+                                                    "be able to set value to None, set nullable=True on "
+                                                    "the Field.".format(self.prop_name))
+
+        self.validate(prop_type, value)
+
+    def __get__(self, obj, type=None):
+        return obj._property_bag[self.prop_name]
+
+    def __set__(self, obj, value):
+        self._handle_validate(obj, value)
+        obj._property_bag[self.prop_name] = value
+
 class ExtensibleBase(object):
     def __init__(self, **kwargs):
         from clims.services.application import ioc
@@ -258,53 +305,6 @@ class ExtensibleBase(object):
 class FieldDoesNotExist(Exception):
     pass
 
-
-class ExtensibleBaseField(object):
-    def __init__(self, prop_name=None, display_name=None, nullable=True):
-        # TODO: Create a metaclass for SubstanceBase that ensures prop_name is always set
-        self.prop_name = prop_name
-        self.display_name = display_name or prop_name
-        self.nullable = nullable
-
-    def validate_with_casting(self, value, fn):
-        valid = True
-        try:
-            cast = fn(value)
-            if cast != value:
-                valid = False
-        except ValueError:
-            valid = False
-
-        if not valid:
-            raise ExtensibleTypeValidationError(
-                "Value can not be interpreted as '{}'".format(fn.__name__))
-
-    def validate(self, prop_type, value):
-        # Override this in subclasses
-        pass
-
-    def _handle_validate(self, obj, value):
-        try:
-            prop_type = obj._archetype.extensible_type.property_types.get(name=self.prop_name)
-        except ExtensiblePropertyType.DoesNotExist:
-            raise FieldDoesNotExist(self.prop_name)
-
-        if value is None:
-            if self.nullable:
-                return
-            else:
-                raise ExtensibleTypeValidationError("None was not a valid value for Field: {}, if you want to "
-                                                    "be able to set value to None, set nullable=True on "
-                                                    "the Field.".format(self.prop_name))
-
-        self.validate(prop_type, value)
-
-    def __get__(self, obj, type=None):
-        return obj._property_bag[self.prop_name]
-
-    def __set__(self, obj, value):
-        self._handle_validate(obj, value)
-        obj._property_bag[self.prop_name] = value
 
 
 class ExtensibleTypeValidationError(Exception):

--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import six
+from six import iteritems
 from clims.models.extensible import (ExtensibleType, ExtensiblePropertyType, ExtensibleProperty)
 from clims.models.location import SubstanceLocation
 from django.db import transaction
@@ -181,7 +182,18 @@ class ExtensibleBaseField(object):
         self._handle_validate(obj, value)
         obj._property_bag[self.prop_name] = value
 
+
+class PropertyInitiator(type):
+    def __new__(cls, clsname, superclasses, attributedict):
+        for k, v in iteritems(attributedict):
+            if issubclass(type(v), ExtensibleBaseField):
+                v.prop_name = k
+        return type.__new__(cls, clsname, superclasses, attributedict)
+
+
 class ExtensibleBase(object):
+    __metaclass__ = PropertyInitiator
+
     def __init__(self, **kwargs):
         from clims.services.application import ioc
         self._app = ioc.app
@@ -304,7 +316,6 @@ class ExtensibleBase(object):
 
 class FieldDoesNotExist(Exception):
     pass
-
 
 
 class ExtensibleTypeValidationError(Exception):

--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -183,18 +183,21 @@ class ExtensibleBaseField(object):
 
 
 class PropertyInitiator(type):
-    def __new__(cls, clsname, superclasses, attributedict):
-        for k, v in iteritems(attributedict):
-            if issubclass(type(v), ExtensibleBaseField):
+    def __new__(cls, name, bases, attrs):
+        # Creates an instance of the new extensible type
+        instance = super(PropertyInitiator, cls).__new__(cls, name, bases, attrs)
+        # Check all the fields of the instance, and add the name of the field
+        # as a default display name.
+        for k, v in iteritems(instance.__dict__):
+            if isinstance(v, ExtensibleBaseField):
                 v.prop_name = k
                 if v.display_name is None:
                     v.display_name = k
-        return type.__new__(cls, clsname, superclasses, attributedict)
+        return instance
 
 
+@six.add_metaclass(PropertyInitiator)
 class ExtensibleBase(object):
-    # This syntax is changed in python 3!
-    __metaclass__ = PropertyInitiator
 
     def __init__(self, **kwargs):
         from clims.services.application import ioc

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -1,16 +1,13 @@
 from __future__ import absolute_import
 
 import random
-
 import pytest
-
 from sentry.testutils import TestCase
-
 from clims.models import Substance, SubstanceVersion
 from clims.services import ExtensibleTypeValidationError
 from clims.services.substance import SubstanceBase
 from clims.services.extensible import FloatField
-
+from clims.services.extensible import TextField
 from django.db import IntegrityError
 from tests.fixtures.plugins.gemstones_inc.models import GemstoneSample, GemstoneContainer
 
@@ -394,3 +391,24 @@ class TestSubstance(SubstanceTestCase):
         #       Then it would be enough to check first.location == "a1" and we could return
         #       this directly to the frontend
         assert (first.location.x, first.location.y, first.location.z) == (0, 0, 0)
+
+    @pytest.mark.dev_edvard
+    def test_with_no_display_name__default_display_name_is_shown(self):
+        self.register_extensible(QuirkSample)
+        ext_type_name = QuirkSample.type_full_name_cls()
+        extensible_type = \
+            self.app.extensibles.get_extensible_type(self.organization, ext_type_name)
+        quirkyness = extensible_type.property_types.get(name='quirkyness')
+
+        assert quirkyness.display_name == 'quirkyness'
+
+    def test_with_explicitly_set_display_name__display_name_is_shown(self):
+        extensible_type = self.register_extensible(QuirkSample)
+        squirkyness = extensible_type.property_types.get(name='squirkyness')
+
+        assert squirkyness.display_name == 'The Squirkyness Display Value'
+
+
+class QuirkSample(SubstanceBase):
+    quirkyness = TextField()
+    squirkyness = TextField(display_name='The Squirkyness Display Value')

--- a/tests/fixtures/plugins/gemstones_inc/models.py
+++ b/tests/fixtures/plugins/gemstones_inc/models.py
@@ -4,16 +4,16 @@ from clims.services import PlateBase
 
 
 class GemstoneSample(SubstanceBase):
-    preciousness = TextField(prop_name="preciousness")  # TODO: Metaclass that sets prop_name
-    color = TextField(prop_name="color")
-    index = IntField(prop_name="index")
-    weight = IntField(prop_name="weight")
-    payload = JsonField(prop_name="payload")
-    has_something = BoolField(prop_name="has_something")
+    preciousness = TextField()
+    color = TextField()
+    index = IntField()
+    weight = IntField()
+    payload = JsonField()
+    has_something = BoolField()
 
 
 class GemstoneContainer(PlateBase):
     rows = 8
     columns = 12
 
-    comment = TextField("comment")
+    comment = TextField()


### PR DESCRIPTION
Purpose:
Simplify declaration of extensible properties so that the statement
myprop1 = TextField(prop_name='myprop1')
goes into
myprop1 = TextField()

That is, the field prop_name is automatically initiated.

Implementation:
The implementation is done in PropertyInitiator, which is a metaclass to ExtensibleBase. The initiation of "display_name" is preserved as before, which is, display_name takes the property name if omitted, otherwise the explicitly set value. 

Points for careful consideration:
I created a classmethod type_full_name_cls(), although there is already a instance method type_full_name(). My thought was that \<display name\> might be needed when rendering a web page without any instances, showing empty columns when there were no hits for example. 