### PR TITLE
Clims 276 hook up project view to backend

### DIFF
--- a/src/clims/runner/commands/create_example_data.py
+++ b/src/clims/runner/commands/create_example_data.py
@@ -61,4 +61,4 @@ def createexampledata():
         name = "demo-{}".format(uuid4().hex)
         project = ExampleProject(name=name, organization=org, project_code=name, pi=random.choice(pis))
         project.save()
-        click.echo("Created sample: {}".format(project.name))
+        click.echo("Created project: {}".format(project.name))

--- a/src/clims/runner/commands/create_example_data.py
+++ b/src/clims/runner/commands/create_example_data.py
@@ -1,6 +1,8 @@
 
 from __future__ import absolute_import, print_function
 import random
+from uuid import uuid4
+
 
 import click
 from sentry.runner.decorators import configuration
@@ -14,7 +16,8 @@ def createexampledata():
     """
     from clims.services.application import ioc, ApplicationService
     from clims.services.substance import SubstanceBase
-    from clims.services.extensible import FloatField
+    from clims.services.project import ProjectBase
+    from clims.services.extensible import FloatField, TextField
     from clims.models.plugin_registration import PluginRegistration
     from sentry.models.organization import Organization
     from clims.models import WorkBatch
@@ -36,7 +39,12 @@ def createexampledata():
         cool = FloatField("cool")
         erudite = FloatField("erudite")
 
+    class ExampleProject(ProjectBase):
+        pi = TextField("pi")
+        project_code = TextField("project_code")
+
     app.extensibles.register(example_plugin, ExampleSample)
+    app.extensibles.register(example_plugin, ExampleProject)
 
     for _ in range(100):
         name = "sample-{}".format(random.randint(1, 1000000))
@@ -47,3 +55,10 @@ def createexampledata():
                                erudite=random.randint(1, 100))
         sample.save()
         click.echo("Created sample: {}".format(sample.name))
+
+    pis = ["Rosaline Franklin", "Charles Darwin", "Gregor Medel"]
+    for _ in range(100):
+        name = "demo-{}".format(uuid4().hex)
+        project = ExampleProject(name=name, organization=org, project_code=name, pi=random.choice(pis))
+        project.save()
+        click.echo("Created sample: {}".format(project.name))

--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -136,9 +136,9 @@ class HasLocationMixin(object):
 
 
 class ExtensibleBaseField(object):
-    def __init__(self, display_name=None, nullable=True):
-        self.prop_name = None
-        self.display_name = display_name or None
+    def __init__(self, display_name=None, nullable=True, prop_name=None):
+        self.prop_name = prop_name
+        self.display_name = display_name
         self.nullable = nullable
 
     def validate_with_casting(self, value, fn):
@@ -190,7 +190,8 @@ class PropertyInitiator(type):
         # as a default display name.
         for k, v in iteritems(instance.__dict__):
             if isinstance(v, ExtensibleBaseField):
-                v.prop_name = k
+                if v.prop_name is None:
+                    v.prop_name = k
                 if v.display_name is None:
                     v.display_name = k
         return instance

--- a/src/sentry/static/sentry/app/redux/actions/projectSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/actions/projectSearchEntry.js
@@ -4,18 +4,20 @@ export const PROJECT_SEARCH_ENTRIES_GET_REQUEST = 'PROJECT_SEARCH_ENTRIES_GET_RE
 export const PROJECT_SEARCH_ENTRIES_GET_SUCCESS = 'PROJECT_SEARCH_ENTRIES_GET_SUCCESS';
 export const PROJECT_SEARCH_ENTRIES_GET_FAILURE = 'PROJECT_SEARCH_ENTRIES_GET_FAILURE';
 
-export const projectSearchEntriesGetRequest = (query, groupBy) => {
+export const projectSearchEntriesGetRequest = (search, groupBy, cursor) => {
   return {
     type: PROJECT_SEARCH_ENTRIES_GET_REQUEST,
-    query,
+    search,
     groupBy,
+    cursor,
   };
 };
 
-export const projectSearchEntriesGetSuccess = projectSearchEntries => {
+export const projectSearchEntriesGetSuccess = (projectSearchEntries, link) => {
   return {
     type: PROJECT_SEARCH_ENTRIES_GET_SUCCESS,
     projectSearchEntries,
+    link,
   };
 };
 
@@ -24,10 +26,15 @@ export const projectSearchEntriesGetFailure = err => ({
   message: err,
 });
 
-export const projectSearchEntriesGet = (query, groupBy) => dispatch => {
-  dispatch(projectSearchEntriesGetRequest(query, groupBy));
+export const projectSearchEntriesGet = (search, groupBy, cursor) => dispatch => {
+  dispatch(projectSearchEntriesGetRequest(search, groupBy, cursor));
+
+  const request = {
+    params: {search, cursor},
+  };
+
   axios
-    .get('/api/0/organizations/lab/projects/?query=' + query)
+    .get('/api/0/organizations/lab/projects/', request)
     .then(res => {
       const formattedData = res.data.reduce(function(map, project) {
         map[project.id] = {
@@ -37,7 +44,7 @@ export const projectSearchEntriesGet = (query, groupBy) => dispatch => {
         };
         return map;
       }, {});
-      dispatch(projectSearchEntriesGetSuccess(formattedData));
+      dispatch(projectSearchEntriesGetSuccess(formattedData, res.headers.link));
     })
     .catch(err => dispatch(projectSearchEntriesGetFailure(err)));
 };

--- a/src/sentry/static/sentry/app/redux/actions/projectSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/actions/projectSearchEntry.js
@@ -1,4 +1,4 @@
-//import axios from 'axios';
+import axios from 'axios';
 
 export const PROJECT_SEARCH_ENTRIES_GET_REQUEST = 'PROJECT_SEARCH_ENTRIES_GET_REQUEST';
 export const PROJECT_SEARCH_ENTRIES_GET_SUCCESS = 'PROJECT_SEARCH_ENTRIES_GET_SUCCESS';
@@ -26,28 +26,18 @@ export const projectSearchEntriesGetFailure = err => ({
 
 export const projectSearchEntriesGet = (query, groupBy) => dispatch => {
   dispatch(projectSearchEntriesGetRequest(query, groupBy));
-  // TODO Remove hard coding here and fetch project data from backend.
-  const data = {
-    1: {
-      id: 1,
-      name: 'test project 1',
-      pi: 'C. Darwin',
-    },
-    2: {
-      id: 2,
-      name: 'test project 2',
-      pi: 'R. Franklin',
-    },
-  };
-  dispatch(projectSearchEntriesGetSuccess(data));
-  //return axios
-  //  .get('/api/0/organizations/lab/projects/?query=' + query)
-  //  .then(res => {
-  //    // TODO: keep the state outside of these
-  //    for (const entry of res.data) {
-  //      setInitialViewState(groupBy, entry);
-  //    }
-  //    dispatch(projectSearchEntriesGetSuccess(res.data));
-  //  })
-  //  .catch(err => dispatch(projectSearchEntriesGetFailure(err)));
+  axios
+    .get('/api/0/organizations/lab/projects/?query=' + query)
+    .then(res => {
+      const formattedData = res.data.reduce(function(map, project) {
+        map[project.id] = {
+          id: project.id,
+          name: project.name,
+          pi: project.properties.pi.value,
+        };
+        return map;
+      }, {});
+      dispatch(projectSearchEntriesGetSuccess(formattedData));
+    })
+    .catch(err => dispatch(projectSearchEntriesGetFailure(err)));
 };

--- a/src/sentry/static/sentry/app/redux/reducers/projectSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/reducers/projectSearchEntry.js
@@ -37,7 +37,7 @@ const projectSearchEntry = (state = initialState, action) => {
         errorMessage: null,
         loading: false,
         byIds: action.projectSearchEntries,
-        visibleSearchEntries: Object.keys(action.projectSearchEntries),
+        visibleIds: Object.keys(action.projectSearchEntries),
         pageLinks: action.link,
       };
     }

--- a/src/sentry/static/sentry/app/redux/reducers/projectSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/reducers/projectSearchEntry.js
@@ -37,6 +37,7 @@ const projectSearchEntry = (state = initialState, action) => {
         errorMessage: null,
         loading: false,
         byIds: action.projectSearchEntries,
+        visibleSearchEntries: Object.keys(action.projectSearchEntries),
         pageLinks: action.link,
       };
     }

--- a/src/sentry/static/sentry/app/redux/reducers/projectSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/reducers/projectSearchEntry.js
@@ -13,8 +13,10 @@ export const initialState = {
   visibleIds: [],
   selectedIds: [],
   groupBy: 'name',
-  query: 'name',
+  search: 'name',
   byIds: {}, // The actual substance entries (TODO: have parentById and childById?)
+  cursor: '', // The cursor into the current dataset
+  paginationEnabled: true,
 };
 
 const projectSearchEntry = (state = initialState, action) => {
@@ -24,8 +26,9 @@ const projectSearchEntry = (state = initialState, action) => {
         ...state,
         errorMessage: null,
         loading: true,
-        query: action.query,
+        search: action.search,
         groupBy: action.groupBy,
+        cursor: action.cursor,
       };
     }
     case PROJECT_SEARCH_ENTRIES_GET_SUCCESS: {
@@ -34,6 +37,7 @@ const projectSearchEntry = (state = initialState, action) => {
         errorMessage: null,
         loading: false,
         byIds: action.projectSearchEntries,
+        pageLinks: action.link,
       };
     }
     case PROJECT_SEARCH_ENTRIES_GET_FAILURE:

--- a/src/sentry/static/sentry/app/views/projects/index.jsx
+++ b/src/sentry/static/sentry/app/views/projects/index.jsx
@@ -17,7 +17,13 @@ class ProjectsContainer extends React.Component {
     // TODO: Consider using react for all of this data
     const access = getOrganizationState(this.props.organization).getAccess();
 
-    return <Projects organization={this.props.organization} access={access} />;
+    return (
+      <Projects
+        organization={this.props.organization}
+        access={access}
+        location={this.props.location}
+      />
+    );
   }
 }
 

--- a/src/sentry/static/sentry/app/views/projects/projects.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projects.jsx
@@ -86,7 +86,7 @@ class Projects extends React.Component {
       {key: 'name', title: t('Project name')},
     ];
 
-    const {groupBy, query, byIds, loading} = this.props.projectSearchEntry;
+    const {groupBy, query, byIds, visibleIds, loading} = this.props.projectSearchEntry;
 
     return (
       <div className="stream-row">
@@ -107,7 +107,7 @@ class Projects extends React.Component {
             columns={this.getHeaders()}
             dataById={byIds}
             canSelect={false}
-            visibleIds={Object.keys(byIds)}
+            visibleIds={visibleIds}
             loading={loading}
           />
           {this.props.projectSearchEntry.paginationEnabled &&

--- a/src/sentry/static/sentry/app/views/projects/projects.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projects.jsx
@@ -6,12 +6,28 @@ import {t} from 'app/locale';
 import ListFilters from 'app/components/listFilters';
 import ListView from 'app/components/listView';
 import SentryTypes from 'app/sentryTypes';
+import Pagination from 'app/components/pagination';
+import {browserHistory} from 'react-router';
 
 class Projects extends React.Component {
   constructor(props) {
     super(props);
-    const {query, groupBy} = this.props;
-    this.props.projectSearchEntriesGet(query, groupBy);
+
+    this.onGroup = this.onGroup.bind(this);
+    this.onSort = this.onSort.bind(this);
+    this.onSearch = this.onSearch.bind(this);
+    this.onCursor = this.onCursor.bind(this);
+
+    let {search, cursor, groupBy} = this.props.projectSearchEntry;
+    const query = this.props.location.query;
+
+    if (query) {
+      search = query.search ? query.search : search;
+      cursor = query.cursor ? query.cursor : cursor;
+      groupBy = query.groupBy ? query.groupBy : groupBy;
+    }
+
+    this.onSearch(search, groupBy, cursor);
   }
 
   getHeaders() {
@@ -34,8 +50,32 @@ class Projects extends React.Component {
     this.setState({groupBy: {value: e}});
   }
 
-  onSearch(query, groupBy) {
-    this.props.projectSearchEntriesGet(query, groupBy);
+  onSearch(search, groupBy, cursor) {
+    this.props.projectSearchEntriesGet(search, groupBy, cursor);
+
+    const location = this.props.location;
+    const query = {
+      ...location.query,
+      search,
+      groupBy,
+      cursor,
+    };
+
+    browserHistory.push({pathname: location.pathname, query});
+  }
+
+  onCursor(cursor) {
+    const {search, groupBy} = this.props.projectSearchEntry;
+    this.onSearch(search, groupBy, cursor);
+  }
+
+  onGroup(e) {
+    // TODO Fix this later (should be set through redux )
+    this.setState({groupBy: {value: e}});
+  }
+
+  onSort(e) {
+    // TODO Fix this later (should be set through redux )
   }
 
   render() {
@@ -46,6 +86,8 @@ class Projects extends React.Component {
       {key: 'name', title: t('Project name')},
     ];
 
+    const {groupBy, query, byIds, loading} = this.props.projectSearchEntry;
+
     return (
       <div className="stream-row">
         <div className="stream-content">
@@ -54,19 +96,27 @@ class Projects extends React.Component {
             onSavedSearchCreate={this.onSavedSearchCreate}
             searchPlaceholder={t('Search for projects')}
             groupOptions={groupOptions}
-            grouping={this.props.groupBy}
+            grouping={groupBy}
             onGroup={this.onGroup}
             onSearch={this.onSearch}
             orgId={this.props.organization.id}
-            query={this.props.query}
+            query={query}
           />
           <ListView
             orgId={this.props.organization.id}
             columns={this.getHeaders()}
-            dataById={this.props.projectSearchEntry.byIds}
+            dataById={byIds}
             canSelect={false}
-            visibleIds={Object.keys(this.props.projectSearchEntry.byIds)}
+            visibleIds={Object.keys(byIds)}
+            loading={loading}
           />
+          {this.props.projectSearchEntry.paginationEnabled &&
+            this.props.projectSearchEntry.pageLinks && (
+              <Pagination
+                pageLinks={this.props.projectSearchEntry.pageLinks}
+                onCursor={this.onCursor}
+              />
+            )}
         </div>
       </div>
     );
@@ -76,11 +126,9 @@ class Projects extends React.Component {
 Projects.propTypes = {
   access: PropTypes.object,
   organization: SentryTypes.Organization.isRequired,
-  groupBy: PropTypes.string.isRequired,
   projectSearchEntriesGet: PropTypes.func.isRequired,
   byIds: PropTypes.object,
   projectSearchEntry: PropTypes.object,
-  query: PropTypes.string,
 };
 
 const mapStateToProps = state => {
@@ -90,7 +138,8 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  projectSearchEntriesGet: query => dispatch(projectSearchEntriesGet(query)),
+  projectSearchEntriesGet: (query, groupBy, cursor) =>
+    dispatch(projectSearchEntriesGet(query, groupBy, cursor)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Projects);


### PR DESCRIPTION
This hooks up the project view to the backend, including enabling pagination.

It also adds some other minor fixes (in separate commits):
 - allows prop names to be set explicitly if the users wants
 - has the data generation script create projects