### PR TITLE
When value have not been prefetched, go get them

### DIFF
--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -393,9 +393,11 @@ class PropertyBag(object):
 
             # '.all_properties' is used to leverage the .prefetch_related() call
             # that is used when fetching the extensible
-            properties = self.extensible_wrapper._wrapped_version.all_properties
-            value = next(prop.value for prop in properties if prop.extensible_property_type.name == key)
-
+            if hasattr(self.extensible_wrapper._wrapped_version, 'all_properties'):
+                properties = self.extensible_wrapper._wrapped_version.all_properties
+                value = next(prop.value for prop in properties if prop.extensible_property_type.name == key)
+            else:
+                value = self.extensible_wrapper._wrapped_version.properties.get(extensible_property_type__name=key).value
             return value
         except ExtensibleProperty.DoesNotExist:
             return None

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -48,6 +48,23 @@ class SubstancePropertiesTestCase(TestCase):
         assert fetched_sample.cool == cool
         assert fetched_sample.erudite == erudite
 
+    def test_can_set_and_get_properties_of_substance(self):
+        moxy = random.randint(1, 100)
+        cool = random.randint(1, 100)
+        erudite = random.randint(1, 100)
+
+        name = "sample-{}".format(random.randint(1, 1000000))
+        sample = self.ExampleSample(name=name,
+                                    organization=self.organization,
+                                    moxy=moxy,
+                                    cool=cool,
+                                    erudite=erudite)
+        sample.save()
+
+        assert sample.moxy == moxy
+        assert sample.erudite == erudite
+        assert sample.cool == cool
+
     def test_can_create_substance_with_property_set_to_none(self):
         name = "sample-{}".format(random.randint(1, 1000000))
         cool = random.randint(1, 100)

--- a/tests/clims/models/test_substance_child.py
+++ b/tests/clims/models/test_substance_child.py
@@ -36,6 +36,13 @@ class TestSubstanceParentChild(SubstanceTestCase):
 
         assert original_prop_vals == child_prop_vals
 
+    def test_simple_child_gets_specific_prop(self):
+        props = dict(preciousness='*o*', color='red')
+        parent = self.create_gemstone(**props)
+        child = parent.create_child()
+        assert child.preciousness == '*o*'
+        assert child.color == 'red'
+
     def test_creating_child_can_override_props(self):
         props = dict(preciousness='*o*', color='red')
         parent = self.create_gemstone(**props)


### PR DESCRIPTION
I'm not sure this is optimal, since for some cases it could lead to unexpected db calls. I.e. you expected to have all the properties prefetched, but in reality they are not, and every get will generate a call to the database.

This is a good enough sketch for now though, I suppose? Later we might want to prefetch them and add them to the object if they are not there. What do you think?