### PR TITLE
WIP: clims-277, proposal for handling of prefetched queries

### DIFF
--- a/src/clims/services/container.py
+++ b/src/clims/services/container.py
@@ -116,8 +116,14 @@ class ContainerBase(ExtensibleBase):
         if not self.is_dirty:
             # We are being updated with an instance from the DB, so we should map
             # all the items that are in it to this container
-            # TODO: Make sure callers are prefetching!
-            for location in self._wrapped_version.archetype.substance_locations.filter(current=True):
+            try:
+                locs = self._wrapped_version.archetype.prefetched_locations
+            except AttributeError:
+                raise AttributeError('Initialization of container failed. The underlying django models has '
+                                     'to be prefetched with substance_locations, which must have been given '
+                                     'attribute name \'prefetched_locations\'. This navigation property sits on '
+                                     'container_version.archetype.')
+            for location in locs:
                 self._locatables[location.raw] = self._app.substances.to_wrapper(location.substance)
 
     def append(self, value):

--- a/src/clims/services/container.py
+++ b/src/clims/services/container.py
@@ -271,3 +271,13 @@ class ContainerService(WrapperMixin, ExtensibleServiceAPIMixin, object):
                 latest=True, name__icontains=val).prefetch_related('properties')
         else:
             raise NotImplementedError("The key {} is not implemented".format(key))
+    def _get_class_specific_prefetches(self):
+        substance_query = SubstanceVersion.objects.filter(latest=True)
+        return [
+            Prefetch('archetype__substance_locations', to_attr='prefetched_locations'),
+            Prefetch('archetype__prefetched_locations__substance'),
+            Prefetch('archetype__prefetched_locations__substance__extensible_type'),
+            Prefetch('archetype__prefetched_locations__substance__versions',
+                     queryset=substance_query, to_attr='prefetched_versions'),
+            Prefetch('archetype__extensible_type'),
+        ]

--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -246,6 +246,7 @@ class ExtensibleBase(object):
             self._wrapped_version.archetype = self._archetype
             self._wrapped_version.name = self._archetype.name
             self._wrapped_version.save()
+            self._archetype.prefetched_versions = [self._wrapped_version]
             self._property_bag.save(self._wrapped_version)
         else:
             # Updating

--- a/src/clims/services/project.py
+++ b/src/clims/services/project.py
@@ -46,5 +46,8 @@ class ProjectService(WrapperMixin, ExtensibleServiceAPIMixin, object):
     _archetype_class = Project
     _archetype_base_class = ProjectBase
 
+    def _get_class_specific_prefetches(self):
+        return []
+
     def __init__(self, app):
         self._app = app

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -255,6 +255,7 @@ class SubstanceBase(HasLocationMixin, WrapperMixin, ExtensibleBase):
         child.save()
         version = SubstanceVersion(archetype=child)
         version.save()
+        child.prefetched_versions = [version]
 
         # Origin points to the first ancestor(s) of this substance. If the substance being cloned
         # has origins, we'll get the same origins. Otherwise the substance being

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -12,6 +12,7 @@ from clims.models.file import MultiFormatFile
 from clims.services.extensible import (ExtensibleBase, HasLocationMixin)
 from django.db import transaction
 from django.db.models import QuerySet
+from django.db.models import Prefetch
 from uuid import uuid4
 from sentry.models.file import File
 from sentry.plugins import plugins
@@ -395,3 +396,10 @@ class SubstanceService(WrapperMixin, ExtensibleServiceAPIMixin, object):
     def get_by_name(self, name):
         # TODO: add organization to the filter parameters
         return self.get(name=name)
+
+    def _get_class_specific_prefetches(self):
+        from django.db.models import Prefetch
+        return [
+            Prefetch('archetype__project'),
+            Prefetch('archetype__project__versions', to_attr='prefetched_versions'),
+        ]

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -54,7 +54,13 @@ class SubstanceAncestry(object):
         # from two original samples. There your pool's origin are the two original samples.
 
         # Now, to find all the nodes in the graph, we simply query for the origin nodes:
-        for entry in Substance.objects.filter(origins__in=self.substance.origins):
+        # TODO: I think this query don't belong here. It should be in SubstanceService.
+        subquery = SubstanceVersion.objects.filter(latest=True)
+        entries = Substance.objects.filter(
+            origins__in=self.substance.origins).prefetch_related(
+            Prefetch('versions', queryset=subquery, to_attr='prefetched_versions')
+        )
+        for entry in entries:
             yield self.substance._to_wrapper(entry)
 
     def to_graphviz_src(self, include_created=True):

--- a/src/clims/services/wrapper.py
+++ b/src/clims/services/wrapper.py
@@ -35,5 +35,14 @@ class WrapperMixin(object):
             return self._archetype_base_class(_wrapped_version=version, _unregistered=True)
 
     def _archetype_to_wrapper(self, archetype):
-        versioned = archetype.versions.get(latest=True)
+        try:
+            versions = archetype.prefetched_versions
+        except AttributeError:
+            raise AttributeError('Failed to wrap instance. The archetype class must have attribute '
+                                 '\'prefetched_versions\'. ')
+        if not len(versions) == 1:
+            raise AttributeError('Failed to wrap instance. The fetched number of versions has to be '
+                                 'exactly one in order for the instansiation to succeed. The desired '
+                                 'version has to be included in the original django search query.')
+        versioned = versions[0]
         return self._version_to_wrapper(versioned)

--- a/tests/clims/models/test_substance_child.py
+++ b/tests/clims/models/test_substance_child.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
 from clims.models import Substance
+from django.db.models import Prefetch
+from clims.models.substance import SubstanceVersion
 from tests.clims.models.test_substance import SubstanceTestCase
 
 
@@ -83,7 +85,11 @@ class TestSubstanceParentChild(SubstanceTestCase):
 
         do_asserts(child)
         # Assert the same is true if we fetch the child by name:
-        child = self.app.substances.to_wrapper(Substance.objects.get(name=child.name))
+        subquery = SubstanceVersion.objects.filter(latest=True)
+        child_model = Substance.objects.prefetch_related(
+            Prefetch('versions', queryset=subquery, to_attr='prefetched_versions')
+        ).get(name=child.name)
+        child = self.app.substances.to_wrapper(child_model)
         do_asserts(child)
 
     def test_can_get_ancestry_from_substance(self):

--- a/tests/clims/services/test_containers.py
+++ b/tests/clims/services/test_containers.py
@@ -1,0 +1,131 @@
+from __future__ import absolute_import
+import pytest
+from exam import before
+from exam import after
+from django.db import connection
+from django.db import reset_queries
+from django.conf import settings
+from django.db.models import Prefetch
+from sentry.testutils import TestCase
+from clims.models.container import ContainerVersion
+from tests.fixtures.plugins.gemstones_inc.models import GemstoneSample
+from clims.services.container import PlateBase
+from clims.services.extensible import TextField
+
+
+class TestContainers(TestCase):
+    @before
+    def init_debug(self):
+        self.old_debug = settings.DEBUG
+        settings.DEBUG = True
+        self.create_container_with_samples(
+            HairSampleContainer, GemstoneSample, 'container1')
+        self.create_container_with_samples(
+            HairSampleContainer, GemstoneSample, 'container2')
+
+    @after
+    def reset_debug(self):
+        settings.DEBUG = self.old_debug
+
+    @pytest.mark.dev_edvard
+    def test_fetch_containers__first_1_container_then_2__same_amount_of_db_calls_for_either_call(self):
+        # Arrange
+        reset_queries()
+        container1_model = self.app.containers._expanded_search('container1')
+        self.app.containers.to_wrapper(container1_model[0])
+        db_calls1 = len(connection.queries)
+        reset_queries()
+        container_models = self.app.containers._expanded_search('container')
+        wrapped_containers = list()
+        for c in container_models:
+            current = self.app.containers.to_wrapper(c)
+            wrapped_containers.append(current)
+
+        db_calls2 = len(connection.queries)
+        assert db_calls1 == db_calls2
+
+    def test_fetch_substance_after_instantiation__no_db_calls(self):
+        # Arrange
+        containers = self.app.containers._expanded_search('container')
+        first = containers[0]
+        reset_queries()
+
+        # Act
+        locations = first.archetype.prefetched_locations
+        substance = locations[0].substance
+        versions = substance.prefetched_versions
+        substance_version = versions[0]
+
+        # Assert
+        assert substance.name.startswith('sample')
+        assert substance_version.latest is True
+        assert len(versions) == 1
+        assert len(connection.queries) == 0
+
+    def test_wrap_container_from_raw_model__no_db_calls(self):
+        # Arrange
+        containers = self.app.containers._expanded_search('container')
+        first = containers[0]
+        reset_queries()
+
+        # Act
+        wrapped_container = self.app.containers.to_wrapper(first)
+
+        from pprint import pprint
+        pprint(connection.queries)
+        # Assert
+        assert wrapped_container.name.startswith('container')
+        assert wrapped_container._wrapped_version.latest is True
+        assert len(connection.queries) == 0
+
+    def test_wrap_sample_from_raw_model__which_is_fetched_from_container__no_db_calls(self):
+        # Arrange
+        containers = self.app.containers._expanded_search('container')
+        first = containers[0]
+        reset_queries()
+
+        # Act
+        wrapped_container = self.app.containers.to_wrapper(first)
+        first_sample = wrapped_container["A1"]
+
+        # Assert
+        assert first_sample.name.startswith('sample')
+        assert first_sample._wrapped_version.latest is True
+        assert len(connection.queries) == 0
+
+    def test_with_no_subquery_for_latest_substance__two_substance_versions_are_fetched(self):
+        # Arrange
+        containers = ContainerVersion.objects.filter(
+            latest=True, name__icontains='container').prefetch_related(
+            Prefetch('archetype__substance_locations', to_attr='locations'),
+            Prefetch('archetype__locations__substance'),
+            Prefetch('archetype__locations__substance__versions', queryset=None),
+            Prefetch('properties'))
+        first = containers[0]
+        reset_queries()
+
+        # Act
+        locations = first.archetype.locations
+        substance = locations[0].substance
+        versions = substance.versions.all()
+
+        # Assert
+        assert substance.name.startswith('sample')
+        assert len(versions) == 2
+        assert len(connection.queries) == 0
+
+    def create_container_with_samples(
+            self, container_class, substance_class, prefix="container", sample_count=10):
+        container = self.create_container(container_class, prefix=prefix)
+        for _ in range(sample_count):
+            sample = self.create_substance(substance_class, color='red')
+            container.append(sample)
+        container.save()
+        return container
+
+
+class HairSampleContainer(PlateBase):
+    rows = 8
+    columns = 12
+
+    comment = TextField("comment")

--- a/tests/fixtures/plugins/gemstones_inc/models.py
+++ b/tests/fixtures/plugins/gemstones_inc/models.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from clims.services import SubstanceBase, ProjectBase, TextField, IntField, FloatField, JsonField, BoolField
-from clims.services import PlateBase
+from clims.services.container import PlateBase
 
 
 class GemstoneProject(ProjectBase):


### PR DESCRIPTION
Purpose:
Prevent excessive db calls when loading extensible types, such as containers, in order to show them in a list in UI. The goal here is to have a constant number of queries regardless of the number of entities found. To be more clear, the situation to be prevented is to query a number of entities in the first round, and then for each found entity do one or more separate queries. 

Implementation:
Entities are queried with the \'to_attr\' flag set. In other parts of the code, when instantiating extensible related classes, this self declared attribute is referred (e.g. prefetched_locations). If entities are queried without having this exact \'to_attr\' value, there will be an error raised. 
* This implementation always fetches all related entities for containers, which is all substances, and releated models for substances.

Benefits:
* Before this implementation, all models related to container, (substances and sub-models) was always fetched, but with separate queries for each found container. These fetches was spread out and hard to get a grip on. 
* This implementation with prefetches gives an overview of what is fetched, instead of having fetches spread out.  
* It will force us to work towards a more centralized query handling

Drawbacks:
* In future development, it may be annoying to bump into this. 

Points for careful consideration:
* In future, we will want to have more tailored and limited queries for different views, only fetching what is shown in the UI. The solution here does not support this as is. 
* Perhaps we should do prefetch but without \'to_attr\'? It will be lesser annoyances, but harder to keep track of the db-roundtrips.
