### PR TITLE
Clims 278 group by sample type

### DIFF
--- a/src/clims/models/extensible.py
+++ b/src/clims/models/extensible.py
@@ -108,6 +108,19 @@ class ExtensiblePropertyType(Model):
         null=False,
     )
 
+    def get_value_field(self):
+        raw_type = self.raw_type
+        if raw_type == ExtensiblePropertyType.INT:
+            return "int_value"
+        elif raw_type == ExtensiblePropertyType.FLOAT:
+            return "float_value"
+        elif raw_type == ExtensiblePropertyType.STRING or raw_type == ExtensiblePropertyType.JSON:
+            return "string_value"
+        elif raw_type == ExtensiblePropertyType.BOOL:
+            return "bool_value"
+        else:
+            raise AssertionError("Unexpected raw type {}".format(raw_type))
+
     class Meta:
         app_label = 'clims'
         db_table = 'clims_extensiblepropertytype'
@@ -146,17 +159,7 @@ class ExtensibleProperty(Model):
         super(ExtensibleProperty, self).__init__(*args, **kwargs)
 
     def _get_field_from_type(self):
-        raw_type = self.extensible_property_type.raw_type
-        if raw_type == ExtensiblePropertyType.INT:
-            return "int_value"
-        elif raw_type == ExtensiblePropertyType.FLOAT:
-            return "float_value"
-        elif raw_type == ExtensiblePropertyType.STRING or raw_type == ExtensiblePropertyType.JSON:
-            return "string_value"
-        elif raw_type == ExtensiblePropertyType.BOOL:
-            return "bool_value"
-        else:
-            raise AssertionError("Unexpected raw type {}".format(raw_type))
+        return self.extensible_property_type.get_value_field()
 
     def _serialize(self, value):
         raw_type = self.extensible_property_type.raw_type

--- a/src/clims/services/extensible_service_api.py
+++ b/src/clims/services/extensible_service_api.py
@@ -105,23 +105,26 @@ class ExtensibleServiceAPIMixin(object):
                 get_args['archetype__{}'.format(key)] = value
         return get_args
 
-    def _get_values_qs(self, property, extensible_type):
+    @staticmethod
+    def _get_values_qs(property, extensible_type):
         extensible_type_name = extensible_type.type_full_name_cls()
         property_query_set = ExtensibleProperty.objects.filter(
             extensible_property_type__extensible_type__name=extensible_type_name,
             extensible_property_type__name=property).select_related('extensible_property_type')
         return property_query_set
 
-    def get_values_of_property(self, property, extensible_type):
-        property_query_set = self._get_values_qs(property, extensible_type)
+    @staticmethod
+    def get_values_of_property(property, extensible_type):
+        property_query_set = ExtensibleServiceAPIMixin._get_values_qs(property, extensible_type)
         extensible_type = property_query_set[0].extensible_property_type
         extensible_type_value_field = extensible_type.get_value_field()
         values = property_query_set.all().values(extensible_type_value_field)
         return ([x[extensible_type_value_field] for x in values])
 
-    def get_unique_values_of_property(self, property, extensible_type):
+    @staticmethod
+    def get_unique_values_of_property(property, extensible_type):
         # TODO: add organization to the filter parameters
-        property_query_set = self._get_values_qs(property, extensible_type)
+        property_query_set = ExtensibleServiceAPIMixin._get_values_qs(property, extensible_type)
         extensible_type = property_query_set[0].extensible_property_type
         extensible_type_value_field = extensible_type.get_value_field()
         unique_values = property_query_set.order_by(extensible_type_value_field).distinct(extensible_type_value_field)

--- a/src/clims/services/extensible_service_api.py
+++ b/src/clims/services/extensible_service_api.py
@@ -116,16 +116,26 @@ class ExtensibleServiceAPIMixin(object):
     @staticmethod
     def get_values_of_property(property, extensible_type):
         property_query_set = ExtensibleServiceAPIMixin._get_values_qs(property, extensible_type)
-        extensible_type = property_query_set[0].extensible_property_type
-        extensible_type_value_field = extensible_type.get_value_field()
-        values = property_query_set.all().values(extensible_type_value_field)
-        return ([x[extensible_type_value_field] for x in values])
+        try:
+            extensible_type = property_query_set[0].extensible_property_type
+            extensible_type_value_field = extensible_type.get_value_field()
+            values = property_query_set.all().values(extensible_type_value_field)
+            return ([x[extensible_type_value_field] for x in values])
+        except IndexError:
+            raise DoesNotExist("No property with name: {} found on extensible type: {}".format(property,
+                                                                                               extensible_type))
 
     @staticmethod
     def get_unique_values_of_property(property, extensible_type):
         # TODO: add organization to the filter parameters
-        property_query_set = ExtensibleServiceAPIMixin._get_values_qs(property, extensible_type)
-        extensible_type = property_query_set[0].extensible_property_type
-        extensible_type_value_field = extensible_type.get_value_field()
-        unique_values = property_query_set.order_by(extensible_type_value_field).distinct(extensible_type_value_field)
-        return set([x.value for x in unique_values])
+        try:
+            property_query_set = ExtensibleServiceAPIMixin._get_values_qs(property, extensible_type)
+            extensible_type = property_query_set[0].extensible_property_type
+            extensible_type_value_field = extensible_type.get_value_field()
+            unique_values = property_query_set\
+                .order_by(extensible_type_value_field)\
+                .distinct(extensible_type_value_field)
+            return set([x.value for x in unique_values])
+        except IndexError:
+            raise DoesNotExist("No property with name: {} found on extensible type: {}".format(property,
+                                                                                               extensible_type))

--- a/src/clims/services/extensible_service_api.py
+++ b/src/clims/services/extensible_service_api.py
@@ -117,10 +117,12 @@ class ExtensibleServiceAPIMixin(object):
     def get_values_of_property(property, extensible_type):
         property_query_set = ExtensibleServiceAPIMixin._get_values_qs(property, extensible_type)
         try:
-            extensible_type = property_query_set[0].extensible_property_type
-            extensible_type_value_field = extensible_type.get_value_field()
-            values = property_query_set.all().values(extensible_type_value_field)
-            return ([x[extensible_type_value_field] for x in values])
+            # Note that this assumes that the property type is the same for all
+            # entities in the property_query_set
+            extensible_property_type = property_query_set[0].extensible_property_type
+            extensible_prop_type_value_field = extensible_property_type.get_value_field()
+            values = property_query_set.all().values(extensible_prop_type_value_field)
+            return ([x[extensible_prop_type_value_field] for x in values])
         except IndexError:
             raise DoesNotExist("No property with name: {} found on extensible type: {}".format(property,
                                                                                                extensible_type))
@@ -128,14 +130,16 @@ class ExtensibleServiceAPIMixin(object):
     @staticmethod
     def get_unique_values_of_property(property, extensible_type):
         # TODO: add organization to the filter parameters
+        property_query_set = ExtensibleServiceAPIMixin._get_values_qs(property, extensible_type)
         try:
-            property_query_set = ExtensibleServiceAPIMixin._get_values_qs(property, extensible_type)
-            extensible_type = property_query_set[0].extensible_property_type
-            extensible_type_value_field = extensible_type.get_value_field()
+            # Note that this assumes that the property type is the same for all
+            # entities in the property_query_set
+            extensible_prop_type = property_query_set[0].extensible_property_type
+            extensible_prop_type_value_field = extensible_prop_type.get_value_field()
             unique_values = property_query_set\
-                .order_by(extensible_type_value_field)\
-                .distinct(extensible_type_value_field)
-            return set([x.value for x in unique_values])
+                .order_by(extensible_prop_type_value_field)\
+                .distinct(extensible_prop_type_value_field)
+            return {x.value for x in unique_values}
         except IndexError:
             raise DoesNotExist("No property with name: {} found on extensible type: {}".format(property,
                                                                                                extensible_type))

--- a/tests/clims/services/test_projects.py
+++ b/tests/clims/services/test_projects.py
@@ -1,3 +1,41 @@
-from __future__ import absolute_import
 
-# TODO Write tests for project service
+from __future__ import absolute_import
+from sentry.testutils import TestCase
+from clims.services.project import ProjectBase
+from clims.services.extensible import TextField
+import random
+
+
+class TestProjectService(TestCase):
+
+    def setUp(self):
+        self.register_extensible(GemstoneProject)
+
+    def create_a_bunch_of_projects(self):
+        country_choices = ['Sweden', 'Norway', 'Denmark', 'Finland', 'Flat Iceland']
+        country_list = []
+        for i in range(0, 100):
+            pick = random.choice(country_choices)
+            project = GemstoneProject(name='project{}'.format(i),
+                                      organization=self.organization,
+                                      country_of_sampling=pick)
+            project.save()
+            country_list.append(pick)
+        return country_list
+
+    def test_get_unique_values_of_property(self):
+        country_choices = set(self.create_a_bunch_of_projects())
+        actual = self.app.substances.get_unique_values_of_property(property='country_of_sampling',
+                                                                   extensible_type=GemstoneProject)
+        assert actual == country_choices
+
+    def test_get_values_of_property(self):
+        country_choices = self.create_a_bunch_of_projects()
+        actual = self.app.substances.get_values_of_property(property='country_of_sampling',
+                                                            extensible_type=GemstoneProject)
+        assert sorted(actual) == sorted(country_choices)
+
+
+class GemstoneProject(ProjectBase):
+    species = TextField("species")
+    country_of_sampling = TextField("country_of_sampling")

--- a/tests/clims/services/test_substances.py
+++ b/tests/clims/services/test_substances.py
@@ -14,6 +14,7 @@ from clims.services import Csv
 from clims.services.project import ProjectBase
 from clims.services.extensible import TextField
 from tests.fixtures.plugins.gemstones_inc.models import GemstoneSample
+from clims.services.exceptions import DoesNotExist
 import random
 
 
@@ -171,6 +172,12 @@ class TestSubstanceService(TestCase):
         actual = self.app.substances.get_values_of_property(property='color',
                                                             extensible_type=GemstoneSample)
         assert sorted(actual) == sorted(color_list)
+
+    def test_get_values_of_nonexistent_property(self):
+        self.create_a_bunch_of_sample()
+        with pytest.raises(DoesNotExist):
+            self.app.substances.get_values_of_property(property='date',
+                                                       extensible_type=GemstoneSample)
 
 
 class GemstoneProject(ProjectBase):

--- a/tests/clims/services/test_substances.py
+++ b/tests/clims/services/test_substances.py
@@ -14,6 +14,7 @@ from clims.services import Csv
 from clims.services.project import ProjectBase
 from clims.services.extensible import TextField
 from tests.fixtures.plugins.gemstones_inc.models import GemstoneSample
+import random
 
 
 def read_binary_file(path):
@@ -144,6 +145,32 @@ class TestSubstanceService(TestCase):
         # Assert
         assert len(fetched_samples) == 1
         assert fetched_samples[0].color == 'red'
+
+    def create_a_bunch_of_sample(self):
+        project1 = GemstoneProject(name='project1', organization=self.organization)
+        project1.save()
+
+        color_choices = set(['red', 'blue', 'green'])
+        color_list = []
+        for i in range(0, 100):
+            sample = GemstoneSample(name='sample{}'.format(i), organization=self.organization, project=project1)
+            color_pick = random.choice(list(color_choices))
+            color_list.append(color_pick)
+            sample.color = color_pick
+            sample.save()
+        return color_list
+
+    def test_get_unique_values_of_property(self):
+        color_choices = set(self.create_a_bunch_of_sample())
+        actual = self.app.substances.get_unique_values_of_property(property='color',
+                                                                   extensible_type=GemstoneSample)
+        assert actual == color_choices
+
+    def test_get_values_of_property(self):
+        color_list = self.create_a_bunch_of_sample()
+        actual = self.app.substances.get_values_of_property(property='color',
+                                                            extensible_type=GemstoneSample)
+        assert sorted(actual) == sorted(color_list)
 
 
 class GemstoneProject(ProjectBase):


### PR DESCRIPTION
This should enable getting values, either all or all unique, values for a property for all extensible types. Right now you need to feed it the `extensible_type`, e.g. `GemstoneSample`. We might instead have the type be picked up from the context (i.e. put the type as a field on the service class), but I think that this is clearer and gives the user more control.

This means that the API needs will look something like this:
```
self.app.substances.get_unique_values_of_property(property='color', extensible_type=GemstoneSample)
```
Let me know what you think.