### PR TITLE
clims 277, group samples by container, fix container endpoint

### DIFF
--- a/src/clims/api/endpoints/container.py
+++ b/src/clims/api/endpoints/container.py
@@ -16,14 +16,14 @@ class ContainerEndpoint(OrganizationEndpoint):
 
     def get(self, request, organization):
         # TODO: Filter by the organization
-        query = request.GET.get('query', '')
+        query_from_url = request.GET.get('query', '')
         expand = request.GET.get('expand', None) == 'true'
         if expand:
             serializer_class = ContainerExpandedSerializer
         else:
             serializer_class = ContainerSerializer
 
-        query_builder = ContainerQueryBuilder(query)
+        query_builder = ContainerQueryBuilder(query_from_url)
         query_builder.order_by_created_date()
         containers = self.app.containers.filter_from(query_builder)
 

--- a/src/clims/api/endpoints/container.py
+++ b/src/clims/api/endpoints/container.py
@@ -6,6 +6,7 @@ from sentry.api.base import DEFAULT_AUTHENTICATION
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.bases.organization import OrganizationEndpoint
 from clims.api.serializers.models.container import ContainerSerializer
+from clims.api.serializers.models.container import ContainerExpandedSerializer
 
 
 class ContainerEndpoint(OrganizationEndpoint):
@@ -15,7 +16,11 @@ class ContainerEndpoint(OrganizationEndpoint):
     def get(self, request, organization):
         # TODO: Filter by the organization
         query = request.GET.get('query', '')
-        # expand = request.GET.get('expand', None) == 'true'
+        expand = request.GET.get('expand', None) == 'true'
+        if expand:
+            serializer_class = ContainerExpandedSerializer
+        else:
+            serializer_class = ContainerSerializer
         queryset = self.app.containers._search_qs(query)
         # Temporarily sort by date
         queryset = queryset.order_by('-archetype__created_at')
@@ -24,7 +29,7 @@ class ContainerEndpoint(OrganizationEndpoint):
             ret = list()
             for entry in qs:
                 wrapper = self.app.containers.to_wrapper(entry)
-                json = ContainerSerializer(wrapper).data
+                json = serializer_class(wrapper).data
                 ret.append(json)
             return ret
 

--- a/src/clims/api/serializers/models/container.py
+++ b/src/clims/api/serializers/models/container.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from clims.api.serializers.models.extensible_property import ExtensiblePropertySerializer
+from clims.api.serializers.models.substance import SubstanceSerializer
 
 from rest_framework import serializers
 from rest_framework.fields import DictField
@@ -12,3 +13,7 @@ class ContainerSerializer(serializers.Serializer):
     name = serializers.CharField()
     properties = DictField(child=ExtensiblePropertySerializer(read_only=True))
     type_full_name = serializers.CharField()
+
+
+class ContainerExpandedSerializer(ContainerSerializer):
+    contents = SubstanceSerializer(many=True)

--- a/src/clims/api/serializers/models/substance.py
+++ b/src/clims/api/serializers/models/substance.py
@@ -4,6 +4,14 @@ from clims.api.serializers.models.extensible_property import ExtensiblePropertyS
 
 from rest_framework import serializers
 from rest_framework.fields import DictField
+from six import text_type
+
+
+class ContainerIndexField(serializers.Field):
+    def to_representation(self, value):
+        return {
+            "index": text_type(value)
+        }
 
 
 class LocationField(serializers.Field):
@@ -26,3 +34,4 @@ class SubstanceSerializer(serializers.Serializer):
     properties = DictField(child=ExtensiblePropertySerializer(read_only=True))
     type_full_name = serializers.CharField()
     location = LocationField(read_only=True)
+    container_index = ContainerIndexField(read_only=True)

--- a/src/clims/services/container.py
+++ b/src/clims/services/container.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import re
 import six
+from six import iteritems
 from clims.services.extensible import ExtensibleBase
 from clims.models import Container, ContainerVersion
 from clims.services.wrapper import WrapperMixin
@@ -157,6 +158,14 @@ class ContainerBase(ExtensibleBase):
         # Update the value. This will not actually move it in the backend until either
         # the container is saved
         self._locatables[ix.raw] = value
+
+    @property
+    def contents(self):
+        c = []
+        for loc_raw, substance in iteritems(self._locatables):
+            c.append(substance)
+
+        return c
 
     def __getitem__(self, key):
         ix = self.IndexType.from_any_type(key)

--- a/src/clims/services/container.py
+++ b/src/clims/services/container.py
@@ -262,41 +262,36 @@ class ContainerService(WrapperMixin, ExtensibleServiceAPIMixin, object):
         return self.get(name=name)
 
     def filter_from(self, query_builder):
-        qs = self._search_qs(query_builder.query, query_builder.order_by)
-        containers = list()
-        for container_model in qs:
-            containers.append(self.to_wrapper(container_model))
+        query_params = query_builder.parse_query()
+        return self.filter(**query_params)
 
-        return containers
 
-    def _search_qs(self, query, order_by=None):
-        # TODO: This is temporary. We will be using elastic for searching.
-        query = query.strip()
+class ContainerQueryBuilder:
+    def __init__(self, query_from_url):
+        self.order_by = None
+        self.query_from_url = query_from_url
+
+    def order_by_created_date(self):
+        self.order_by = '-archetype__created_at'
+
+    def parse_query(self):
+        query_params = dict()
+        if self.order_by:
+            query_params['order_by'] = self.order_by
+        query = self.query_from_url.strip()
+        if len(query) == 0:
+            return query_params
         query = query.split(" ")
+
         if len(query) > 1:
             raise NotImplementedError("Complex queries are not yet supported")
-        elif len(query) == 0:
-            qs = self._all_qs()
 
         query = query[0]
         key, val = query.split(":")
 
         if key == "container.name":
-            # TODO: the search parameter indicates we're looking for a substance that's a sample
-            # so add a category or similar so it doesn't find other things that are in a container.
-            qs = ContainerVersion.objects.filter(
-                latest=True, name__icontains=val).prefetch_related('properties')
+            query_params['name__icontains'] = val
         else:
             raise NotImplementedError("The key {} is not implemented".format(key))
-        if order_by:
-            qs.order_by(order_by)
-        return qs
+        return query_params
 
-
-class ContainerQueryBuilder:
-    def __init__(self, query):
-        self.order_by = None
-        self.query = query
-
-    def order_by_created_date(self):
-        self.order_by = '-archetype__created_at'

--- a/src/clims/services/extensible_service_api.py
+++ b/src/clims/services/extensible_service_api.py
@@ -62,11 +62,14 @@ class ExtensibleServiceAPIMixin(object):
             raise NotImplementedError("The key {} is not implemented".format(key))
 
     def filter(self, **kwargs):
+        order_by_arg = kwargs.pop('order_by', None)
         get_args = self._get_filter_arguments(**kwargs)
         models = self._archetype_version_class.objects.prefetch_related(
             Prefetch('properties', to_attr='all_properties'),
             Prefetch('all_properties__extensible_property_type')).\
             filter(**get_args)
+        if order_by_arg:
+            models = models.order_by(order_by_arg)
         return [self.to_wrapper(m) for m in models]
 
     def get(self, **kwargs):

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -181,6 +181,18 @@ class SubstanceBase(HasLocationMixin, WrapperMixin, ExtensibleBase):
         self._archetype.project = project._archetype
 
     @property
+    def container_index(self):
+        # TODO: the container should be in a local cache!
+        # when looping samples in a container, the very same container is fetched over and
+        # over again
+        loc = self.location
+        container = self._app.containers.to_wrapper(loc.container)
+        container_index_class = container.IndexType
+        # Can we assume that container index class has only row and column, not z?
+        ind = container_index_class(loc.y, loc.x)
+        return ind
+
+    @property
     def location(self):
         # TODO: Prefetch the current position
         # TODO: Wrap in a higher level object that makes sense (e.g. PlateIndex, which

--- a/tests/clims/api/endpoints/test_container.py
+++ b/tests/clims/api/endpoints/test_container.py
@@ -11,7 +11,6 @@ from tests.fixtures.plugins.gemstones_inc.models import GemstoneSample, Gemstone
 
 
 class ContainerTest(APITestCase):
-    @pytest.mark.dev_edvard
     def test_find_single_container_by_container_name(self):
         # TODO: This takes too much time for 10 containers filled with samples
         container = self.create_container_with_samples(
@@ -28,6 +27,7 @@ class ContainerTest(APITestCase):
         assert serializer.is_valid()
         assert expanded_serializer.is_valid() is False
 
+    @pytest.mark.dev_edvard
     def test_can_expand_samples_when_searching(self):
         # Arrange
         container = self.create_container_with_samples(
@@ -48,5 +48,6 @@ class ContainerTest(APITestCase):
         type_full_name = response.data[0]['contents'][0]['type_full_name']
         assert type_full_name == 'tests.fixtures.plugins.gemstones_inc.models.GemstoneSample'
         assert response.data[0]['contents'][0]['location']['index'] == '(0, 1, 0)'
+        assert response.data[0]['contents'][0]['container_index']['index'] == 'B:1'
         serializer = ContainerExpandedSerializer(data=response.data[0])
         assert serializer.is_valid()

--- a/tests/clims/models/test_container.py
+++ b/tests/clims/models/test_container.py
@@ -5,7 +5,8 @@ import uuid
 import pytest
 from six import text_type
 from sentry.testutils import TestCase
-from clims.services import SubstanceBase, PlateBase
+from clims.services import SubstanceBase
+from clims.services.container import PlateBase
 from clims.services import FloatField, TextField
 from clims.models import Container
 from django.db import IntegrityError
@@ -64,6 +65,7 @@ class TestContainer(TestCase):
         location = model.locations.get(current=True)
         assert (location.x, location.y, location.z) == (0, 0, 0)
 
+    @pytest.mark.dev_edvard
     def test_can_traverse_plate(self):
         self.register_extensible(HairSampleContainer)
         self.register_extensible(HairSample)


### PR DESCRIPTION
Purpose:
Prepare the container endpoint to be able to show an expandable list of containers in UI. User first see a list of containers. When user clicks on a selected container, all samples in that container are shown. 

Implementation:
Fix an expanded http response from the container endpoint, that contains json for all contained samples. 

Refactoring:
I intended to remove low level django quering, and container wrapping from the container endpoint. For this I created the ContainerQueryBuilder. I also called the base class .filter method in order to do the wrapping. 