### PR TITLE
clims 320, show all samples and projects at first visit

### DIFF
--- a/src/sentry/static/sentry/app/redux/reducers/projectSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/reducers/projectSearchEntry.js
@@ -12,8 +12,8 @@ export const initialState = {
   allVisibleSelected: false,
   visibleIds: [],
   selectedIds: [],
-  groupBy: 'name',
-  search: 'name',
+  groupBy: 'Project name',
+  search: 'project.name:',
   byIds: {}, // The actual substance entries (TODO: have parentById and childById?)
   cursor: '', // The cursor into the current dataset
   paginationEnabled: true,

--- a/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
@@ -16,7 +16,7 @@ export const initialState = {
   substanceSearchEntries: [],
   allVisibleSelected: false,
   groupBy: 'substance',
-  search: '',
+  search: 'sample.name:',
   byIds: {}, // The actual substance entries (TODO: have parentById and childById?)
   visibleIds: [], // Sorted list of items visible in the current page
   selectedIds: new Set(), // The set of items selected, allowed to be outside of the current page


### PR DESCRIPTION
Purpose:
When user first visits the Samples or the Projects view, show all items as default.