### PR TITLE
Stop using the global `plugins` variable

### DIFF
--- a/src/clims/api/endpoints/plugin_actions.py
+++ b/src/clims/api/endpoints/plugin_actions.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from sentry.plugins import plugins
 from sentry.api.base import Endpoint, SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 
@@ -18,7 +17,7 @@ class PluginActionsEndpoint(Endpoint):
 
     def post(self, request, organization_slug, plugin_id):
         correlation = request.data
-        plugin = plugins.get(correlation["plugin"])
+        plugin = self.app.plugins.get(correlation["plugin"])
         plugin.handle_event(correlation["handler"], correlation["method"], request.data)
 
         return Response({}, 201)

--- a/src/clims/api/endpoints/work_batch_settings.py
+++ b/src/clims/api/endpoints/work_batch_settings.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.base import DocSection
 from rest_framework.response import Response
-from sentry.plugins import plugins
 from sentry.api.serializers import serialize
 from sentry.api.exceptions import ResourceDoesNotExist
 
@@ -12,13 +11,13 @@ class WorkBatchSettingsEndpoint(OrganizationEndpoint):
     doc_section = DocSection.ORGANIZATIONS
 
     def get(self, request, organization):
-        ret = plugins.all_work_batches()
+        ret = self.app.plugins.all_work_batches()
         return Response(serialize(ret))
 
 
 class WorkBatchSettingsDetailsEndpoint(OrganizationEndpoint):
     def get(self, request, organization, work_batch_type):
-        if work_batch_type not in plugins.handlers_mapped_by_work_batch_type:
+        if work_batch_type not in self.app.plugins.handlers_mapped_by_work_batch_type:
             raise ResourceDoesNotExist()
-        ret = plugins.handlers_mapped_by_work_batch_type[work_batch_type]
+        ret = self.app.plugins.handlers_mapped_by_work_batch_type[work_batch_type]
         return Response(serialize(ret))

--- a/src/clims/services/application.py
+++ b/src/clims/services/application.py
@@ -4,7 +4,8 @@ from clims.services.extensible import ExtensibleService
 from clims.services.substance import SubstanceService
 from clims.services.container import ContainerService
 from clims.services.project import ProjectService
-from sentry.plugins import plugins
+from clims.services.workflow import WorkflowService
+from sentry.plugins import PluginManager
 
 
 class ApplicationService(object):
@@ -17,9 +18,8 @@ class ApplicationService(object):
         self.substances = SubstanceService(self)
         self.containers = ContainerService(self)
         self.projects = ProjectService(self)
-        # TODO: Stop using this global "singleton". Using it since some legacy code accesses
-        # the plugins via `from sentry.plugins import plugins` rather than via `app.plugins`
-        self.plugins = plugins
+        self.plugins = PluginManager(self)
+        self.workflows = WorkflowService(self)
 
 
 class InversionOfControl(object):

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -18,6 +18,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from simplejson import JSONDecodeError
 
+from clims.services.application import ioc
 from sentry import tsdb
 from sentry.utils.cursors import Cursor
 from sentry.utils.dates import to_datetime
@@ -65,10 +66,7 @@ class Endpoint(APIView):
 
     @property
     def app(self):
-        if not hasattr(self, "_app"):
-            from clims.services import ApplicationService
-            self._app = ApplicationService()
-        return self._app
+        return ioc.app
 
     def build_cursor_link(self, request, name, cursor):
         querystring = u'&'.join(

--- a/src/sentry/api/endpoints/organization_plugins.py
+++ b/src/sentry/api/endpoints/organization_plugins.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from sentry.plugins import plugins
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization_plugin import OrganizationPluginSerializer
@@ -13,12 +12,12 @@ from sentry.models import ProjectOption
 class OrganizationPluginsEndpoint(OrganizationEndpoint):
     def get(self, request, organization):
         all_plugins = dict([
-            (p.slug, p) for p in plugins.all()
+            (p.slug, p) for p in self.app.plugins.all()
         ])
 
         if 'plugins' in request.GET:
             if request.GET.get('plugins') == '_all':
-                return Response(serialize([p for p in plugins.all()],
+                return Response(serialize([p for p in self.app.plugins.all()],
                                           request.user, PluginSerializer()))
 
             desired_plugins = set(request.GET.getlist('plugins'))

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -127,7 +127,7 @@ class GroupSerializerBase(Serializer):
         return results
 
     def get_attrs(self, item_list, user):
-        from sentry.plugins import plugins
+        from clims.services import ioc
 
         GroupMeta.objects.populate_cache(item_list)
 
@@ -227,9 +227,9 @@ class GroupSerializerBase(Serializer):
             active_date = item.active_at or item.first_seen
 
             annotations = []
-            for plugin in plugins.for_project(project=item.project, version=1):
+            for plugin in ioc.app.plugins.for_project(project=item.project, version=1):
                 safe_execute(plugin.tags, None, item, annotations, _with_transaction=False)
-            for plugin in plugins.for_project(project=item.project, version=2):
+            for plugin in ioc.app.plugins.for_project(project=item.project, version=2):
                 annotations.extend(
                     safe_execute(plugin.get_annotations, group=item, _with_transaction=False) or ()
                 )

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -437,7 +437,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
         return attrs
 
     def serialize(self, obj, attrs, user):
-        from sentry.plugins import plugins
+        from clims.services import ioc
 
         data = super(DetailedProjectSerializer,
                      self).serialize(obj, attrs, user)
@@ -506,7 +506,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 'plugins':
                 serialize(
                     [
-                        plugin for plugin in plugins.configurable_for_project(obj, version=None)
+                        plugin for plugin in ioc.app.plugins.configurable_for_project(obj, version=None)
                         if plugin.has_project_conf()
                     ], user, PluginSerializer(obj)
                 ),

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -15,6 +15,7 @@ from sentry.app import tsdb
 from sentry.digests import Record
 from sentry.utils.dates import to_timestamp
 from functools import reduce
+from clims.services import ioc
 
 logger = logging.getLogger('sentry.digests')
 
@@ -22,10 +23,9 @@ Notification = namedtuple('Notification', 'event rules')
 
 
 def split_key(key):
-    from sentry.plugins import plugins  # XXX
     from sentry.models import Project  # Django 1.9 setup issue
     plugin_slug, _, project_id = key.split(':', 2)
-    return plugins.get(plugin_slug), Project.objects.get(pk=project_id)
+    return ioc.app.plugins.get(plugin_slug), Project.objects.get(pk=project_id)
 
 
 def unsplit_key(plugin, project):

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -40,7 +40,7 @@ from sentry.models import (
     Project, Release, ReleaseEnvironment, ReleaseProject,
     ReleaseProjectEnvironment, UserReport
 )
-from sentry.plugins import plugins
+from clims.services import ioc
 from sentry.signals import event_discarded, event_saved, first_event_received
 from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.utils import metrics
@@ -177,7 +177,7 @@ def generate_culprit(data, platform=None):
 
 def plugin_is_regression(group, event):
     project = event.project
-    for plugin in plugins.for_project(project):
+    for plugin in ioc.app.plugins.for_project(project):
         result = safe_execute(
             plugin.is_regression, group, event, version=1, _with_transaction=False
         )
@@ -700,7 +700,7 @@ class EventManager(object):
         # clients did not set this appropriately so far.
         normalize_in_app(data)
 
-        for plugin in plugins.for_project(project, version=None):
+        for plugin in ioc.app.plugins.for_project(project, version=None):
             added_tags = safe_execute(plugin.get_tags, event, _with_transaction=False)
             if added_tags:
                 # plugins should not override user provided tags

--- a/src/sentry/management/commands/check_notifications.py
+++ b/src/sentry/management/commands/check_notifications.py
@@ -11,12 +11,12 @@ from optparse import make_option
 
 from django.core.management.base import BaseCommand, CommandError
 
+from clims.services import ioc
 from sentry.models import User
 
 
 def find_mail_plugin():
-    from sentry.plugins import plugins
-    for plugin in plugins.all():
+    for plugin in ioc.app.plugins.all():
         if type(plugin).__name__.endswith('MailPlugin'):
             return plugin
     assert False, 'MailPlugin cannot be found'

--- a/src/sentry/mediators/plugins/migrator.py
+++ b/src/sentry/mediators/plugins/migrator.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
+from clims.services import ioc
 from sentry.mediators import Mediator, Param
 from sentry.models import Repository
-from sentry.plugins import plugins
 from sentry.utils.cache import memoize
 
 
@@ -12,7 +12,7 @@ class Migrator(Mediator):
 
     def call(self):
         for project in self.projects:
-            for plugin in plugins.for_project(project):
+            for plugin in ioc.app.plugins.for_project(project):
                 if plugin.slug != self.integration.provider:
                     continue
 
@@ -54,7 +54,7 @@ class Migrator(Mediator):
     @property
     def plugins(self):
         return [
-            plugins.configurable_for_project(project)
+            ioc.app.plugins.configurable_for_project(project)
             for project in self.projects
         ]
 

--- a/src/sentry/plugins/base/__init__.py
+++ b/src/sentry/plugins/base/__init__.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import
 from .bindings import BindingManager
 from .manager import (PluginManager,  # noqa
         PluginMustHaveVersion, PluginIncorrectVersionFormat, RequiredPluginCannotLoad)  # noqa
-from sentry.utils.managers import InstanceManager
 from .notifier import *  # NOQA
 from .response import *  # NOQA
 from .structs import *  # NOQA
@@ -18,5 +17,3 @@ from .v1 import *  # NOQA
 from .v2 import *  # NOQA
 
 bindings = BindingManager()
-
-plugins = PluginManager(InstanceManager())

--- a/src/sentry/plugins/base/group_api_urls.py
+++ b/src/sentry/plugins/base/group_api_urls.py
@@ -5,8 +5,7 @@ import re
 
 from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
 from django.conf.urls import patterns, include, url
-
-from sentry.plugins import plugins
+from clims.services import ioc
 
 logger = logging.getLogger('sentry.plugins')
 
@@ -41,4 +40,4 @@ def load_plugin_urls(plugins):
     return urlpatterns
 
 
-urlpatterns = load_plugin_urls(plugins.all())
+urlpatterns = load_plugin_urls(ioc.app.plugins.all())

--- a/src/sentry/plugins/base/manager.py
+++ b/src/sentry/plugins/base/manager.py
@@ -139,8 +139,6 @@ class PluginManager(object):
             plugin.get_name_and_version()))
         from clims.services import ExtensibleBase
         from clims.models import PluginRegistration
-        from clims.services import ApplicationService
-        app = ApplicationService()
 
         # TODO: Mark ExtensibleBase and SubstanceBase so that they are not registered, so the
         # knowledge of which bases are not to be registered is elsewhere
@@ -160,7 +158,7 @@ class PluginManager(object):
         for _name, class_to_register in inspect.getmembers(mod, inspect.isclass):
             if issubclass(class_to_register, ExtensibleBase) and \
                     class_to_register not in known_bases:
-                app.extensibles.register(plugin_model, class_to_register)
+                self._app.extensibles.register(plugin_model, class_to_register)
 
     # Find
 

--- a/src/sentry/plugins/base/project_api_urls.py
+++ b/src/sentry/plugins/base/project_api_urls.py
@@ -6,7 +6,7 @@ import re
 from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
 from django.conf.urls import patterns, include, url
 
-from sentry.plugins import plugins
+from clims.services import ioc
 
 logger = logging.getLogger('sentry.plugins')
 
@@ -41,4 +41,4 @@ def load_plugin_urls(plugins):
     return urlpatterns
 
 
-urlpatterns = load_plugin_urls(plugins.all())
+urlpatterns = load_plugin_urls(ioc.app.plugins.all())

--- a/src/sentry/plugins/base/urls.py
+++ b/src/sentry/plugins/base/urls.py
@@ -4,11 +4,11 @@ import re
 
 from django.conf.urls import patterns, include, url
 
-from sentry.plugins import plugins
+from clims.services import ioc
 
 urlpatterns = patterns('')
 
-for _plugin in plugins.all():
+for _plugin in ioc.app.plugins.all():
     _plugin_url_module = _plugin.get_url_module()
     if _plugin_url_module:
         urlpatterns += (url('^%s/' % re.escape(_plugin.slug), include(_plugin_url_module)), )

--- a/src/sentry/rules/__init__.py
+++ b/src/sentry/rules/__init__.py
@@ -14,7 +14,7 @@ from .registry import RuleRegistry  # NOQA
 
 def init_registry():
     from sentry.constants import SENTRY_RULES
-    from sentry.plugins import plugins
+    from clims.services import ioc
     from sentry.utils.imports import import_string
     from sentry.utils.safe import safe_execute
 
@@ -22,7 +22,7 @@ def init_registry():
     for rule in SENTRY_RULES:
         cls = import_string(rule)
         registry.add(cls)
-    for plugin in plugins.all(version=2):
+    for plugin in ioc.app.plugins.all(version=2):
         for cls in (safe_execute(plugin.get_rules, _with_transaction=False) or ()):
             registry.add(cls)
 

--- a/src/sentry/rules/actions/notify_event.py
+++ b/src/sentry/rules/actions/notify_event.py
@@ -9,7 +9,7 @@ Used for notifying *all* enabled plugins
 
 from __future__ import absolute_import
 
-from sentry.plugins import plugins
+from clims.services import ioc
 from sentry.rules.actions.base import EventAction
 from sentry.rules.actions.services import LegacyPluginService
 from sentry.utils import metrics
@@ -23,12 +23,12 @@ class NotifyEventAction(EventAction):
         from sentry.plugins.bases.notify import NotificationPlugin
 
         results = []
-        for plugin in plugins.for_project(self.project, version=1):
+        for plugin in ioc.app.plugins.for_project(self.project, version=1):
             if not isinstance(plugin, NotificationPlugin):
                 continue
             results.append(LegacyPluginService(plugin))
 
-        for plugin in plugins.for_project(self.project, version=2):
+        for plugin in ioc.app.plugins.for_project(self.project, version=2):
             for notifier in (safe_execute(plugin.get_notifiers, _with_transaction=False) or ()):
                 results.append(LegacyPluginService(notifier))
 

--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -8,19 +8,16 @@ sentry.runner.commands.upgrade
 from __future__ import absolute_import, print_function
 
 import click
-import django
 
 import logging
 from sentry.runner.decorators import configuration
 
 logger = logging.getLogger(__name__)
 
-DJANGO_17 = django.VERSION[0] > 1 or (django.VERSION[0] == 1 and django.VERSION[1] >= 7)
-
 
 def _upgrade(interactive, traceback, verbosity, repair):
     from django.core.management import call_command as dj_call_command
-    from sentry.plugins import plugins
+    from clims.services import ioc
     dj_call_command(
         'migrate',
         interactive=interactive,
@@ -37,7 +34,7 @@ def _upgrade(interactive, traceback, verbosity, repair):
             'sentry.runner.commands.repair.repair',
         )
 
-    plugins.auto_install()
+    ioc.app.plugins.auto_install()
 
 
 @click.command()

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -233,8 +233,10 @@ def initialize_app(config, skip_service_validation=False):
 
     bind_cache_to_option_store()
 
-    from sentry.plugins import plugins
-    plugins.load_installed()
+    from clims.services.application import ioc, ApplicationService
+    app = ApplicationService()
+    ioc.set_application(app)
+    app.plugins.load_installed()
 
     initialize_receivers()
 

--- a/src/sentry/stacktraces.py
+++ b/src/sentry/stacktraces.py
@@ -212,12 +212,12 @@ def normalize_in_app(data):
 
 
 def should_process_for_stacktraces(data):
-    from sentry.plugins import plugins
+    from clims.services import ioc
     infos = find_stacktraces_in_data(data)
     platforms = set()
     for info in infos:
         platforms.update(info.platforms or ())
-    for plugin in plugins.all(version=2):
+    for plugin in ioc.app.plugins.all(version=2):
         processors = safe_execute(
             plugin.get_stacktrace_processors,
             data=data,
@@ -231,14 +231,14 @@ def should_process_for_stacktraces(data):
 
 
 def get_processors_for_stacktraces(data, infos):
-    from sentry.plugins import plugins
+    from clims.services import ioc
 
     platforms = set()
     for info in infos:
         platforms.update(info.platforms or ())
 
     processors = []
-    for plugin in plugins.all(version=2):
+    for plugin in ioc.app.plugins.all(version=2):
         processors.extend(
             safe_execute(
                 plugin.get_stacktrace_processors,

--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -18,14 +18,14 @@ logger = logging.getLogger(__name__)
 
 def get_activity_notifiers(project):
     from sentry.plugins.bases.notify import NotificationPlugin
-    from sentry.plugins import plugins
+    from clims.services import ioc
 
     results = []
-    for plugin in plugins.for_project(project, version=1):
+    for plugin in ioc.app.plugins.for_project(project, version=1):
         if isinstance(plugin, NotificationPlugin):
             results.append(plugin)
 
-    for plugin in plugins.for_project(project, version=2):
+    for plugin in ioc.app.plugins.for_project(project, version=2):
         for notifier in (safe_execute(plugin.get_notifiers, _with_transaction=False) or ()):
             results.append(notifier)
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -13,10 +13,10 @@ import time
 
 from django.conf import settings
 
+from clims.services import ioc
 from sentry import features
 from sentry.utils import snuba
 from sentry.utils.cache import cache
-from sentry.plugins import plugins
 from sentry.signals import event_processed
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
@@ -135,7 +135,7 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
                             event=event,
                         )
 
-        for plugin in plugins.for_project(event.project):
+        for plugin in ioc.app.plugins.for_project(event.project):
             plugin_post_process_group(
                 plugin_slug=plugin.slug,
                 event=event,
@@ -186,7 +186,7 @@ def plugin_post_process_group(plugin_slug, event, **kwargs):
     with configure_scope() as scope:
         scope.set_tag("project", event.project_id)
 
-    plugin = plugins.get(plugin_slug)
+    plugin = ioc.app.plugins.get(plugin_slug)
     safe_execute(plugin.post_process, event=event, group=event.group, **kwargs)
 
 

--- a/src/sentry/tasks/signals.py
+++ b/src/sentry/tasks/signals.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from sentry.plugins import plugins
+from clims.services import ioc
 from sentry.tasks.base import instrumented_task
 from sentry.utils.safe import safe_execute
 
@@ -14,8 +14,8 @@ def signal(name, payload, project_id=None, **kwargs):
     else:
         project = None
 
-    for plugin in plugins.for_project(project, version=1):
+    for plugin in ioc.app.plugins.for_project(project, version=1):
         safe_execute(plugin.handle_signal, name=name, payload=payload, project=project)
 
-    for plugin in plugins.for_project(project, version=2):
+    for plugin in ioc.app.plugins.for_project(project, version=2):
         safe_execute(plugin.handle_signal, name=name, payload=payload, project=project)

--- a/src/sentry/web/frontend/admin.py
+++ b/src/sentry/web/frontend/admin.py
@@ -24,7 +24,7 @@ from django.views.decorators.csrf import csrf_protect
 from sentry import options
 from sentry.app import env
 from sentry.models import Project, User
-from sentry.plugins import plugins
+from clims.services import ioc
 from sentry.utils.email import send_mail
 from sentry.utils.http import absolute_uri
 from sentry.utils.warnings import DeprecatedSettingWarning, UnsupportedBackend, seen_warnings
@@ -35,7 +35,7 @@ from sentry.web.helpers import render_to_response, render_to_string
 
 
 def configure_plugin(request, slug):
-    plugin = plugins.get(slug)
+    plugin = ioc.app.plugins.get(slug)
     if not plugin.has_site_conf():
         return HttpResponseRedirect(auth.get_login_url())
 
@@ -201,7 +201,7 @@ def status_packages(request):
             sorted([(p.project_name, p.version) for p in pkg_resources.working_set]),
             'extensions': [
                 (p.get_title(), '%s.%s' % (p.__module__, p.__class__.__name__))
-                for p in plugins.all(version=None)
+                for p in ioc.app.plugins.all(version=None)
             ],
         },
         request

--- a/src/sentry/web/frontend/group_plugin_action.py
+++ b/src/sentry/web/frontend/group_plugin_action.py
@@ -4,8 +4,8 @@ from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from sudo.utils import is_safe_url
 
+from clims.services import ioc
 from sentry.models import Group, GroupMeta
-from sentry.plugins import plugins
 from sentry.web.frontend.base import ProjectView
 
 
@@ -16,7 +16,7 @@ class GroupPluginActionView(ProjectView):
         group = get_object_or_404(Group, pk=group_id, project=project)
 
         try:
-            plugin = plugins.get(slug)
+            plugin = ioc.app.plugins.get(slug)
         except KeyError:
             raise Http404('Plugin not found')
 

--- a/src/sentry/web/frontend/release_webhook.py
+++ b/src/sentry/web/frontend/release_webhook.py
@@ -15,7 +15,7 @@ from django.utils.decorators import method_decorator
 from sentry.api import client
 from sentry.exceptions import HookValidationError
 from sentry.models import ApiKey, Project, ProjectOption
-from sentry.plugins import plugins
+from clims.services import ioc
 from sentry.utils import json
 
 logger = logging.getLogger('sentry.webhooks')
@@ -113,7 +113,7 @@ class ReleaseWebhookView(View):
         if plugin_id == 'builtin':
             return self._handle_builtin(request, project)
 
-        plugin = plugins.get(plugin_id)
+        plugin = ioc.app.plugins.get(plugin_id)
         if not plugin.is_enabled(project):
             logger.warn('release-webhook.plugin-disabled', extra={
                 'project_id': project_id,

--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -20,7 +20,7 @@ logger = logging.getLogger('sentry')
 
 def get_default_context(request, existing_context=None, team=None):
     from sentry import options
-    from sentry.plugins import plugins
+    from clims.services import ioc
     from django.contrib.auth.models import AnonymousUser  # Django 1.9 setup issue
     from sentry.api.serializers.base import serialize  # Django 1.9 setup issue
     from sentry.models import Team  # Django 1.9 setup issue
@@ -29,7 +29,7 @@ def get_default_context(request, existing_context=None, team=None):
         'CSRF_COOKIE_NAME': settings.CSRF_COOKIE_NAME,
         'URL_PREFIX': options.get('system.url-prefix'),
         'SINGLE_ORGANIZATION': settings.SENTRY_SINGLE_ORGANIZATION,
-        'PLUGINS': plugins,
+        'PLUGINS': ioc.app.plugins,
         'ALLOWED_HOSTS': list(settings.ALLOWED_HOSTS),
         'ONPREMISE': settings.SENTRY_ONPREMISE,
     }

--- a/tests/clims/api/endpoints/test_sample_submission.py
+++ b/tests/clims/api/endpoints/test_sample_submission.py
@@ -8,7 +8,6 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.urlresolvers import reverse
 from sentry.testutils import APITestCase
 from clims.models import OrganizationFile
-from sentry.plugins import plugins
 
 
 logger = logging.getLogger(__name__)
@@ -33,8 +32,8 @@ class TestSampleSubmission(APITestCase):
         with open(get_fixture_path("samples/gemstones-samplesubmission.csv"), mode='rb') as f:
             content = f.read()
         # Register both plugins. Both have an implementation of
-        plugins.register(GemstonePlugin)
-        plugins.register(GemstoneIncPlugin)
+        self.app.plugins.register(GemstonePlugin)
+        self.app.plugins.register(GemstoneIncPlugin)
 
         url = reverse(
             'clims-api-0-organization-substances-files',

--- a/tests/clims/plugins/test_plugins.py
+++ b/tests/clims/plugins/test_plugins.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import pytest
 from sentry.testutils import TestCase
-from sentry.plugins import plugins
 from mock import MagicMock
 from sentry.plugins import (PluginMustHaveVersion, PluginIncorrectVersionFormat, PluginManager,
         RequiredPluginCannotLoad)
@@ -18,23 +17,23 @@ class TestPlugins(TestCase):
         # Makes sure that the demo plugin shipped with the framework installs correctly
         # A similar call is made during `lims upgrade`, so all users have the demo plugin installed
         # by default.
-        plugins.auto_install()  # Only installs information about the plugins in the database
-        plugins.load_installed()  # Loads instances so they can be used
+        self.app.plugins.auto_install()  # Only installs information about the plugins in the database
+        self.app.plugins.load_installed()  # Loads instances so they can be used
         # Materialize the plugins:
-        list(plugins.all())
+        list(self.app.plugins.all())
 
     def test_plugin_must_have_version(self):
         SomePlugin = MagicMock()
         SomePlugin.version = None
         SomePlugin.__name__ = "test"
         with pytest.raises(PluginMustHaveVersion):
-            plugins.install_plugins(SomePlugin)
+            self.app.plugins.install_plugins(SomePlugin)
 
     def test_plugin_must_have_sortable_version(self):
         # Plugins must define a version string that can be parsed to a tuple of numbers
 
         with pytest.raises(PluginIncorrectVersionFormat):
-            plugins.install_plugins(self.PluginWithIncorrectVersionFixture)
+            self.app.plugins.install_plugins(self.PluginWithIncorrectVersionFixture)
 
 
 class TestPluginsVersionLoadChecks(TestCase):

--- a/tests/clims/services/test_substances.py
+++ b/tests/clims/services/test_substances.py
@@ -7,7 +7,6 @@ import StringIO
 import logging
 from tests.clims.models.test_substance import SubstanceTestCase
 from clims.models.substance import Substance
-from sentry.plugins import plugins
 from sentry.testutils import TestCase
 from clims.handlers import SubstancesSubmissionHandler
 from clims.services import Csv
@@ -43,7 +42,7 @@ class TestGemstoneSampleSubmission(SubstanceTestCase):
         logger.setLevel(logging.CRITICAL)
 
         # TODO: It would be cleaner to have the plugins instance in the ApplicationService
-        plugins.handlers.add_handler_implementation(SubstancesSubmissionHandler, MyHandler)
+        self.app.plugins.handlers.add_handler_implementation(SubstancesSubmissionHandler, MyHandler)
 
     def test_run_gemstone_sample_submission_handler__with_csv__6_samples_found_in_db(self):
         # Arrange

--- a/tests/sentry/plugins/testutils.py
+++ b/tests/sentry/plugins/testutils.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
-from sentry.plugins import plugins, IssueTrackingPlugin2
+from clims.services import ioc
+from sentry.plugins import IssueTrackingPlugin2
 
 
 class VstsPlugin(IssueTrackingPlugin2):
@@ -22,12 +23,12 @@ class BitbucketPlugin(IssueTrackingPlugin2):
 
 
 def unregister_mock_plugins():
-    plugins.unregister(VstsPlugin)
-    plugins.unregister(GitHubPlugin)
-    plugins.unregister(BitbucketPlugin)
+    ioc.app.plugins.unregister(VstsPlugin)
+    ioc.app.plugins.unregister(GitHubPlugin)
+    ioc.app.plugins.unregister(BitbucketPlugin)
 
 
 def register_mock_plugins():
-    plugins.register(VstsPlugin)
-    plugins.register(GitHubPlugin)
-    plugins.register(BitbucketPlugin)
+    ioc.app.plugins.register(VstsPlugin)
+    ioc.app.plugins.register(GitHubPlugin)
+    ioc.app.plugins.register(BitbucketPlugin)


### PR DESCRIPTION
Code should use the PluginManager from the ApplicationService. It's
shared via the global ioc object or by dependency injection.