### PR TITLE
278 prepare expandable list

### DIFF
--- a/src/sentry/static/sentry/app/components/icons.jsx
+++ b/src/sentry/static/sentry/app/components/icons.jsx
@@ -19,6 +19,10 @@ import {
   faExclamationTriangle,
   faInfoCircle,
   faBug,
+  faCaretUp,
+  faCaretDown,
+  faCaretRight,
+  faCaretLeft,
 } from '@fortawesome/free-solid-svg-icons';
 
 // Find more fontawesome icons here: https://fontawesome.com/icons?d=gallery&s=solid&m=free
@@ -40,6 +44,10 @@ export const Error = () => <FontAwesomeIcon icon={faExclamationCircle} />;
 export const Warning = () => <FontAwesomeIcon icon={faExclamationTriangle} />;
 export const Info = () => <FontAwesomeIcon icon={faInfoCircle} />;
 export const Debug = () => <FontAwesomeIcon icon={faBug} />;
+export const CaretUp = () => <FontAwesomeIcon icon={faCaretUp} />;
+export const CaretDown = () => <FontAwesomeIcon icon={faCaretDown} />;
+export const CaretRight = () => <FontAwesomeIcon icon={faCaretRight} />;
+export const CaretLeft = () => <FontAwesomeIcon icon={faCaretLeft} />;
 
 // Returns a colored icon for a particular issue
 export function getIssueIcon(type, hasDefaultColor) {

--- a/src/sentry/static/sentry/app/components/listView.jsx
+++ b/src/sentry/static/sentry/app/components/listView.jsx
@@ -3,6 +3,7 @@ import styled from 'react-emotion';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import LoadingError from 'app/components/loadingError';
 import {Panel, PanelBody} from 'app/components/panels';
+import {CaretDown, CaretRight} from 'app/components/icons';
 import PropTypes from 'prop-types';
 import Checkbox from 'app/components/checkbox';
 
@@ -66,6 +67,33 @@ class ListView extends React.Component {
     listActionBar: PropTypes.object,
   };
 
+  constructor() {
+    super();
+    this.state = {
+      expandedRows: [],
+    };
+  }
+
+  handleRowClick(rowId) {
+    const currentlyExpandedRows = this.state.expandedRows;
+    const isRowExpanded = currentlyExpandedRows.includes(rowId);
+    const newExpandedRows = isRowExpanded
+      ? currentlyExpandedRows.filter(id => id !== rowId)
+      : currentlyExpandedRows.concat(rowId);
+
+    this.setState({expandedRows: newExpandedRows});
+  }
+
+  renderRowExpander(rowId) {
+    const currentlyExpandedRows = this.state.expandedRows;
+    const isRowExpanded = currentlyExpandedRows.includes(rowId);
+    if (isRowExpanded) {
+      return <CaretDown />;
+    } else {
+      return <CaretRight />;
+    }
+  }
+
   getDisplayCell(entryId, header) {
     const row = this.props.dataById[entryId];
 
@@ -94,6 +122,11 @@ class ListView extends React.Component {
             <table>
               <thead>
                 <tr>
+                  {
+                    <th>
+                      <div />
+                    </th>
+                  }
                   {this.props.canSelect && (
                     <th>
                       <Checkbox
@@ -115,6 +148,7 @@ class ListView extends React.Component {
                 {this.props.visibleIds.map(entryId => {
                   return (
                     <tr key={'parent-' + entryId}>
+                      <td>{this.renderRowExpander(entryId)}</td>
                       {this.props.canSelect && (
                         <td>
                           <Checkbox

--- a/src/sentry/static/sentry/app/components/listView.jsx
+++ b/src/sentry/static/sentry/app/components/listView.jsx
@@ -126,11 +126,9 @@ class ListView extends React.Component {
             <table>
               <thead>
                 <tr>
-                  {
-                    <th>
-                      <div />
-                    </th>
-                  }
+                  <th>
+                    <div />
+                  </th>
                   {this.props.canSelect && (
                     <th>
                       <Checkbox

--- a/src/sentry/static/sentry/app/components/listView.jsx
+++ b/src/sentry/static/sentry/app/components/listView.jsx
@@ -6,6 +6,7 @@ import {Panel, PanelBody} from 'app/components/panels';
 import {CaretDown, CaretRight} from 'app/components/icons';
 import PropTypes from 'prop-types';
 import Checkbox from 'app/components/checkbox';
+import {Set} from 'immutable';
 
 const ColumnHeader = styled('div')`
   font-size: 14px;
@@ -84,9 +85,13 @@ class ListView extends React.Component {
     this.setState({expandedRows: newExpandedRows});
   }
 
-  renderRowExpander(rowId) {
+  renderRowExpander(entryId) {
+    const entryData = this.props.dataById[entryId];
+    if (!entryData.isGroupHeader) {
+      return '';
+    }
     const currentlyExpandedRows = this.state.expandedRows;
-    const isRowExpanded = currentlyExpandedRows.includes(rowId);
+    const isRowExpanded = currentlyExpandedRows.includes(entryId);
     if (isRowExpanded) {
       return <CaretDown />;
     } else {
@@ -96,7 +101,6 @@ class ListView extends React.Component {
 
   getDisplayCell(entryId, header) {
     const row = this.props.dataById[entryId];
-
     if (typeof header.accessor === 'function') {
       return header.accessor(row);
     }

--- a/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
@@ -30,11 +30,16 @@ export const substanceSearchEntriesGetRequest = (search, groupBy, cursor) => {
   };
 };
 
-export const substanceSearchEntriesGetSuccess = (substanceSearchEntries, link) => {
+export const substanceSearchEntriesGetSuccess = (
+  substanceSearchEntries,
+  link,
+  isGroupHeader
+) => {
   return {
     type: SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS,
     substanceSearchEntries,
     link,
+    isGroupHeader,
   };
 };
 
@@ -43,21 +48,46 @@ export const substanceSearchEntriesGetFailure = err => ({
   message: err,
 });
 
-export const substanceSearchEntriesGet = (search, groupBy, cursor) => dispatch => {
+export const substanceSearchEntriesGet = (
+  search,
+  groupBy,
+  cursor,
+  isGroupHeader
+) => dispatch => {
   dispatch(substanceSearchEntriesGetRequest(search, groupBy, cursor));
 
-  const request = {
-    params: {
-      search,
-      cursor,
-    },
-  };
-  return axios
-    .get('/api/0/organizations/lab/substances/', request)
-    .then(res => {
-      dispatch(substanceSearchEntriesGetSuccess(res.data, res.headers.link));
-    })
-    .catch(err => dispatch(substanceSearchEntriesGetFailure(err)));
+  if (!isGroupHeader) {
+    const request = {
+      params: {
+        search,
+        cursor,
+      },
+    };
+    return axios
+      .get('/api/0/organizations/lab/substances/', request)
+      .then(res => {
+        dispatch(
+          substanceSearchEntriesGetSuccess(res.data, res.headers.link, isGroupHeader)
+        );
+      })
+      .catch(err => dispatch(substanceSearchEntriesGetFailure(err)));
+  } else {
+    // TODO: search and cursor should be implemented as well
+    const request = {
+      params: {
+        unique: true,
+      },
+    };
+    const url = '/api/0/organizations/lab/substances/property/' + groupBy + '/';
+    return axios
+      .get(url, request)
+      .then(res => {
+        dispatch(
+          substanceSearchEntriesGetSuccess(res.data, res.headers.link, isGroupHeader)
+        );
+      })
+      .catch(err => dispatch(substanceSearchEntriesGetFailure(err)));
+  }
 };
 
 export const substanceSearchEntriesToggleSelectAll = doSelect => {

--- a/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
@@ -1,4 +1,3 @@
-import merge from 'lodash/merge';
 import {Set} from 'immutable';
 
 import {
@@ -49,16 +48,23 @@ const substanceSearchEntry = (state = initialState, action) => {
       // The action provides us with the raw data as a list, here we turn it into
       // a dictionary and then update the store's byIds as required.
       const byIds = {};
+      let i = 1;
       for (const entry of action.substanceSearchEntries) {
-        byIds[entry.id] = entry;
+        const groupedEntry = {
+          id: i++,
+          name: entry,
+        };
+        const adaptedEntry = action.isGroupHeader ? groupedEntry : entry;
+        adaptedEntry.isGroupHeader = action.isGroupHeader;
+        byIds[adaptedEntry.id] = adaptedEntry;
       }
-      const visibleIds = action.substanceSearchEntries.map(x => x.id);
+      const visibleIds = Object.keys(byIds).map(Number);
 
       return {
         ...state,
         errorMessage: null,
         loading: false,
-        byIds: merge({}, state.byIds, byIds),
+        byIds,
         visibleIds,
         pageLinks: action.link,
       };

--- a/src/sentry/static/sentry/app/views/substances/substances.jsx
+++ b/src/sentry/static/sentry/app/views/substances/substances.jsx
@@ -40,7 +40,8 @@ class Substances extends React.Component {
   }
 
   onSearch(search, groupBy, cursor) {
-    this.props.substanceSearchEntriesGet(search, groupBy, cursor);
+    const isGroupHeader = groupBy !== 'substance';
+    this.props.substanceSearchEntriesGet(search, groupBy, cursor, isGroupHeader);
 
     // Add search to history
     const location = this.props.location;
@@ -235,8 +236,8 @@ const mapStateToProps = state => {
 // TODO: Rename all functions in `mapDispatchToProps` in other files so that they match the action
 // creators name for consistency.
 const mapDispatchToProps = dispatch => ({
-  substanceSearchEntriesGet: (query, groupBy, cursor) =>
-    dispatch(substanceSearchEntriesGet(query, groupBy, cursor)),
+  substanceSearchEntriesGet: (query, groupBy, cursor, isGroupHeader) =>
+    dispatch(substanceSearchEntriesGet(query, groupBy, cursor, isGroupHeader)),
   substanceSearchEntriesToggleSelectAll: doSelect =>
     dispatch(substanceSearchEntriesToggleSelectAll(doSelect)),
   substanceSearchEntryToggleSelect: (id, doSelect) =>

--- a/src/sentry/static/sentry/app/views/substances/substances.jsx
+++ b/src/sentry/static/sentry/app/views/substances/substances.jsx
@@ -122,6 +122,8 @@ class Substances extends React.Component {
 
   onGroup(e) {
     this.setState({groupBy: {value: e}});
+    const {search, cursor} = this.props.substanceSearchEntry;
+    this.onSearch(search, e, cursor);
   }
 
   onSort(e) {}

--- a/src/sentry/static/sentry/app/views/substances/substances.jsx
+++ b/src/sentry/static/sentry/app/views/substances/substances.jsx
@@ -82,36 +82,49 @@ class Substances extends React.Component {
       {
         Header: 'Container',
         id: 'container',
-        accessor: d => (d.location ? d.location.container.name : '<No location>'),
+        accessor: d =>
+          d.isGroupHeader
+            ? null
+            : d.location ? d.location.container.name : '<No location>',
       },
       {
         Header: 'Index',
         id: 'index',
-        accessor: d => (d.location ? d.location.index : '<No location>'),
+        accessor: d =>
+          d.isGroupHeader ? null : d.location ? d.location.index : '<No location>',
         aggregate: vals => '',
       },
       {
         Header: 'Volume',
         id: 'volume',
         accessor: d =>
-          d.properties.volume ? showRounded(d.properties.volume.value) : null,
+          d.isGroupHeader
+            ? null
+            : d.properties && d.properties.volume
+              ? showRounded(d.properties.volume.value)
+              : null,
         aggregate: vals => '',
       },
       {
         Header: 'Sample Type',
         id: 'sample_type',
-        accessor: d => (d.properties.sample_type ? d.properties.sample_type.value : null),
+        accessor: d =>
+          d.isGroupHeader
+            ? null
+            : d.properties && d.properties.sample_type
+              ? d.properties.sample_type.value
+              : null,
       },
       {
         Header: 'Priority',
         id: 'priority',
-        accessor: d => d.priority,
+        accessor: d => (d.isGroupHeader ? null : d.priority),
         aggregate: vals => '',
       },
       {
         Header: 'Waiting',
         id: 'days_waiting',
-        accessor: d => d.days_waiting,
+        accessor: d => (d.isGroupHeader ? null : d.days_waiting),
       },
     ];
   }

--- a/tests/js/fixtures/substances.js
+++ b/tests/js/fixtures/substances.js
@@ -43,6 +43,33 @@ export function SubstanceSearchEntry(groupBy, id) {
   throw Error('Unknown groupBy: ' + groupBy);
 }
 
+function GroupedEntryFromReducer(groupBy, id) {
+  return {
+    id,
+    name: groupBy + id,
+  };
+}
+
+function SubstanceEntryFromReducer(groupBy, id, isGroupHeader) {
+  let entry = null;
+  if (!isGroupHeader) {
+    entry = SubstanceSearchEntry(groupBy, id);
+  } else {
+    entry = GroupedEntryFromReducer(groupBy, id);
+  }
+  entry.isGroupHeader = isGroupHeader;
+  return entry;
+}
+
+export function SubstanceEntriesFromReducer(count, groupBy) {
+  const ret = [];
+  const isGroupHeader = groupBy !== 'sample';
+  for (let i = 0; i < count; i++) {
+    ret.push(SubstanceEntryFromReducer(groupBy, i + 1, isGroupHeader));
+  }
+  return ret;
+}
+
 export function SubstanceSearchEntries(count, groupBy) {
   const ret = [];
   for (let i = 0; i < count; i++) {

--- a/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
@@ -69,7 +69,9 @@ describe('substance redux actions', function() {
       });
 
       const search = 'search';
-      const groupBy = 'substances';
+      const groupBy = 'substance';
+      const cursor = undefined;
+      const isGroupHeader = false;
 
       const expectedActions = [
         {
@@ -77,15 +79,64 @@ describe('substance redux actions', function() {
           search,
           groupBy,
         },
-        {type: SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS, substanceSearchEntries},
+        {
+          type: SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS,
+          substanceSearchEntries,
+          isGroupHeader,
+        },
       ];
 
       // TODO: return
-      return store.dispatch(substanceSearchEntriesGet(search, groupBy)).then(() => {
-        expect(store.getActions()).toEqual(expectedActions);
-        const request = moxios.requests.mostRecent();
-        expect(request.url).toBe('/api/0/organizations/lab/substances/?search=search');
-      });
+      return store
+        .dispatch(substanceSearchEntriesGet(search, groupBy, cursor, isGroupHeader))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+          const request = moxios.requests.mostRecent();
+          expect(request.url).toBe('/api/0/organizations/lab/substances/?search=search');
+        });
+    });
+
+    it('should create an action to GET grouped substances', () => {
+      const mockResponseGrouped = ['sample_type1'];
+
+      const substanceSearchEntries = mockResponseGrouped;
+      const store = mockStore({substances: []});
+
+      moxios.stubRequest(
+        '/api/0/organizations/lab/substances/property/sample_type/?unique=true',
+        {
+          status: 200,
+          responseText: substanceSearchEntries,
+          headers: [],
+        }
+      );
+
+      const search = 'search';
+      const groupBy = 'sample_type';
+      const cursor = undefined;
+      const isGroupHeader = true;
+
+      const expectedActions = [
+        {
+          type: SUBSTANCE_SEARCH_ENTRIES_GET_REQUEST,
+          search,
+          groupBy,
+        },
+        {
+          type: SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS,
+          isGroupHeader,
+          substanceSearchEntries,
+        },
+      ];
+      return store
+        .dispatch(substanceSearchEntriesGet(search, groupBy, cursor, isGroupHeader))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+          const request = moxios.requests.mostRecent();
+          expect(request.url).toBe(
+            '/api/0/organizations/lab/substances/property/sample_type/?unique=true'
+          );
+        });
     });
   });
 

--- a/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
@@ -39,25 +39,75 @@ describe('substance reducer', () => {
     });
   });
 
-  it('should handle SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS', () => {
+  it('should handle SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS for not-grouped', () => {
+    // Arrange
     const prevState = {
       ...initialState,
       loading: true,
       errorMessage: 'oops',
     };
 
-    const nextState = substanceSearchEntry(prevState, {
+    const action = {
       type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
-      substanceSearchEntries: mockResponseNoGroup,
+      substanceSearchEntries: JSON.parse(JSON.stringify(mockResponseNoGroup)),
+      isGroupHeader: false,
       link: 'some-link',
-    });
+    };
 
+    // Act
+    const nextState = substanceSearchEntry(prevState, action);
+
+    // Assert
+
+    const responseFromReducer = TestStubs.SubstanceEntriesFromReducer(2, 'sample');
+    const mockedByIds = keyBy(responseFromReducer, entry => entry.id);
     expect(nextState).toEqual({
       ...prevState,
       errorMessage: null,
       loading: false,
       visibleIds: [1, 2],
-      byIds: mockResponseNoGroupById,
+      byIds: mockedByIds,
+      pageLinks: 'some-link',
+    });
+  });
+
+  it('should handle SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS for grouped', () => {
+    // Arrange
+    const mockResponseGrouped = ['my_sample_type'];
+
+    const action = {
+      type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
+      substanceSearchEntries: JSON.parse(JSON.stringify(mockResponseGrouped)),
+      link: 'some-link',
+      isGroupHeader: true,
+    };
+
+    const prevState = {
+      ...initialState,
+      loading: true,
+      errorMessage: 'oops',
+    };
+
+    // Act
+    const nextState = substanceSearchEntry(prevState, action);
+
+    // Assert
+    const mockedResponseFromReducer = [
+      {
+        id: 1,
+        name: 'my_sample_type',
+        isGroupHeader: true,
+      },
+    ];
+
+    const mockedByIds = keyBy(mockedResponseFromReducer, entry => entry.id);
+
+    expect(nextState).toEqual({
+      ...prevState,
+      errorMessage: null,
+      loading: false,
+      visibleIds: [1],
+      byIds: mockedByIds,
       pageLinks: 'some-link',
     });
   });

--- a/tests/js/spec/views/__snapshots__/listview.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/listview.spec.jsx.snap
@@ -1,0 +1,151 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`instantiate listview listView according to snapshot 1`] = `
+ListView {
+  "context": Object {},
+  "props": Object {
+    "allVisibleSelected": false,
+    "canSelect": false,
+    "columns": Array [
+      Object {
+        "Header": "Sample name",
+        "accessor": "name",
+        "aggregate": [Function],
+        "id": "name",
+      },
+      Object {
+        "Header": "Container",
+        "accessor": [Function],
+        "id": "container",
+      },
+      Object {
+        "Header": "Sample Type",
+        "accessor": [Function],
+        "id": "sample_type",
+      },
+    ],
+    "dataById": Object {
+      "1": Object {
+        "id": 1,
+        "isGroupHeader": true,
+        "name": "Zombie brain",
+      },
+    },
+    "errorMessage": "",
+    "listActionBar": Object {},
+    "loading": false,
+    "selectedIds": Immutable.Set [],
+    "toggleAll": [MockFunction],
+    "toggleSingle": [MockFunction],
+    "visibleIds": Array [
+      1,
+    ],
+  },
+  "refs": Object {},
+  "state": Object {
+    "expandedRows": Array [],
+  },
+  "updater": Updater {
+    "_callbacks": Array [],
+    "_renderer": ReactShallowRenderer {
+      "_context": Object {},
+      "_element": <ListView
+        allVisibleSelected={false}
+        canSelect={false}
+        columns={
+          Array [
+            Object {
+              "Header": "Sample name",
+              "accessor": "name",
+              "aggregate": [Function],
+              "id": "name",
+            },
+            Object {
+              "Header": "Container",
+              "accessor": [Function],
+              "id": "container",
+            },
+            Object {
+              "Header": "Sample Type",
+              "accessor": [Function],
+              "id": "sample_type",
+            },
+          ]
+        }
+        dataById={
+          Object {
+            "1": Object {
+              "id": 1,
+              "isGroupHeader": true,
+              "name": "Zombie brain",
+            },
+          }
+        }
+        errorMessage=""
+        listActionBar={Object {}}
+        loading={false}
+        selectedIds={Immutable.Set []}
+        toggleAll={[MockFunction]}
+        toggleSingle={[MockFunction]}
+        visibleIds={
+          Array [
+            1,
+          ]
+        }
+      />,
+      "_forcedUpdate": false,
+      "_instance": [Circular],
+      "_newState": null,
+      "_rendered": <Panel>
+        Object {}
+        <PanelBody
+          direction="column"
+          disablePadding={true}
+          flex={false}
+        >
+          <Styles>
+            <table>
+              <thead>
+                <tr>
+                  <th>
+                    <div />
+                  </th>
+                  <th>
+                    <ColumnHeader>
+                      Sample name
+                    </ColumnHeader>
+                  </th>
+                  <th>
+                    <ColumnHeader>
+                      Container
+                    </ColumnHeader>
+                  </th>
+                  <th>
+                    <ColumnHeader>
+                      Sample Type
+                    </ColumnHeader>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <CaretRight />
+                  </td>
+                  <td>
+                    Zombie brain
+                  </td>
+                  <td />
+                  <td />
+                </tr>
+              </tbody>
+            </table>
+          </Styles>
+        </PanelBody>
+      </Panel>,
+      "_rendering": false,
+      "_updater": [Circular],
+    },
+  },
+}
+`;

--- a/tests/js/spec/views/listview.spec.jsx
+++ b/tests/js/spec/views/listview.spec.jsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import ListView from 'app/components/listView.jsx';
+import {shallow} from 'enzyme';
+import {Set} from 'immutable';
+
+describe('instantiate listview', function() {
+  const oneSample = {
+    dataById: {
+      1: {
+        id: 1,
+        name: 'mysample',
+        location: {
+          container: {
+            name: 'mycontainer',
+          },
+        },
+        properties: {
+          sample_type: {
+            value: 'Zombie brain',
+          },
+        },
+      },
+    },
+    visibleIds: [1],
+  };
+
+  const oneSampleType = {
+    dataById: {
+      1: {
+        id: 1,
+        name: 'Zombie brain',
+        isGroupHeader: true,
+      },
+    },
+    visibleIds: [1],
+  };
+
+  const headers = [
+    {
+      Header: 'Sample name',
+      id: 'name',
+      accessor: 'name',
+      aggregate: vals => '',
+    },
+    {
+      Header: 'Container',
+      id: 'container',
+      accessor: d =>
+        d.isGroupHeader ? null : d.location ? d.location.container.name : '<No location>',
+    },
+    {
+      Header: 'Sample Type',
+      id: 'sample_type',
+      accessor: d =>
+        d.isGroupHeader
+          ? null
+          : d.properties.sample_type ? d.properties.sample_type.value : null,
+    },
+  ];
+
+  function renderListView(args) {
+    const defaultProps = {
+      columns: headers,
+      errorMessage: '',
+      loading: false,
+      canSelect: false,
+      allVisibleSelected: false,
+      toggleAll: jest.fn(),
+      toggleSingle: jest.fn(),
+      visibleIds: [],
+      selectedIds: new Set(),
+      dataById: {},
+      listActionBar: {},
+    };
+    const props = {...defaultProps, ...args};
+    return shallow(<ListView {...props} />);
+  }
+  it('listView according to snapshot', () => {
+    const wrapper = renderListView({...oneSampleType});
+    expect(wrapper.instance()).toMatchSnapshot();
+  });
+
+  function fetchElement(wrapper, index) {
+    return wrapper
+      .find('td')
+      .at(index)
+      .text();
+  }
+
+  it('column entries ok for 1 sample', () => {
+    const wrapper = renderListView({...oneSample});
+    const notick = fetchElement(wrapper, 0);
+    expect(notick).toBe('');
+    const sampleName = fetchElement(wrapper, 1);
+    expect(sampleName).toBe('mysample');
+    const location = fetchElement(wrapper, 2);
+    expect(location).toBe('mycontainer');
+    const sampleType = fetchElement(wrapper, 3);
+    expect(sampleType).toBe('Zombie brain');
+  });
+
+  it('column entries ok for 1 group header', () => {
+    const wrapper = renderListView({...oneSampleType});
+    const tick = fetchElement(wrapper, 0);
+    expect(tick).toBe('<CaretRight />');
+    const sampleTypeName = fetchElement(wrapper, 1);
+    expect(sampleTypeName).toBe('Zombie brain');
+    const location = fetchElement(wrapper, 2);
+    expect(location).toBe('');
+    const sampleType = fetchElement(wrapper, 3);
+    expect(sampleType).toBe('');
+  });
+});


### PR DESCRIPTION
Purpose:
Prepare to make expandable rows in substance listview. Depending on the value in 'group by' dropdown, decide which api resource to call, either substances or substance property. In substance listview, show mini-arrows in order to expand a grouped row. Also, adjust the rendering of a row depending of if it's grouped or ordinary.

Implementation:
The response from the api call (json) is enhanced with some properties that are added in the reducer. In case of a substance, the field 'isGroupHeader' is added.The substance property comes as a string and is converted to json in the reducer, and the fields 'isGroupHeader', 'id', and 'name' is added. 'Id' is temporarily and is needed to render it in the listview.

Points for careful consideration:
I'm considering to have different action creators/reducer pair for the grouped api call. I'm not satisfied with the current solution since 1) there is a if/else clause on isGroupHeader in both action creator and reducer, which make these two classes tightly coupled. 2) there are rather long blocks of code. I have not settled my mind of this as of yet, because two sets of action/reducers might be heavy, each reducer carries a lot of state. 

Comment:
The large number of rows is due to the update of yarn.lock. I'm not sure why this file was updated in such extent. I think I gave the command 'yarn install'. Should it be included by the version handling?