### PR TITLE
Downgrade python to 2.7.16 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: bionic
 sudo: required
 language: python
-python: 2.7
+python: 2.7.16
 
 cache:
   yarn: true


### PR DESCRIPTION
This is a temporary downgrade as builds are currently failing