### PR TITLE
clims-0, fix create example data

### DIFF
--- a/src/clims/plugins/demo/handlers/create_example_data.py
+++ b/src/clims/plugins/demo/handlers/create_example_data.py
@@ -4,7 +4,7 @@ import logging
 from uuid import uuid4
 
 from clims.handlers import CreateExampleDataHandler
-from clims.plugins.demo.models import ExampleSample, ExampleProject, Plate96
+from clims.plugins.demo.models import ExampleSample, ExampleProject, PandorasBox
 from clims.plugins.demo import DemoPlugin
 from clims.models.plugin_registration import PluginRegistration
 
@@ -26,7 +26,7 @@ class DemoCreateExampleDataHandler(CreateExampleDataHandler):
         demo_plugin, _ = PluginRegistration.objects.get_or_create(
             name=demo_plugin_full_name,
             version='1.0.0')
-        self.app.extensibles.register(demo_plugin, Plate96)
+        self.app.extensibles.register(demo_plugin, PandorasBox)
 
         logger.info("Creating example data for the builtin Demo plugin")
 
@@ -41,14 +41,14 @@ class DemoCreateExampleDataHandler(CreateExampleDataHandler):
             return
 
         available_containers = []
-        for ix in range(3):
+        for ix in range(100):
             id = ix + 1
             # id = uuid4().hex
-            name = 'container-{}'.format(id)
+            name = 'pandora-{}'.format(id)
             try:
                 container = self.app.containers.get(name=name)
             except self.app.containers.DoesNotExist:
-                container = Plate96(name=name, organization=self.context.organization)
+                container = PandorasBox(name=name, organization=self.context.organization)
                 container.save()
                 logger.info('Created container: {}'.format(container.name))
             available_containers.append(container)
@@ -67,7 +67,7 @@ class DemoCreateExampleDataHandler(CreateExampleDataHandler):
             sample.save()
             logger.info("Created sample: {}".format(sample.name))
             plate = random.choice(available_containers)
-            if not sample.location:
+            if not sample.location and len(plate.contents) < plate.rows * plate.columns:
                 plate.append(sample)
                 sample.save()
                 logger.info("Appended sample: {}".format(sample.name))

--- a/src/clims/plugins/demo/models.py
+++ b/src/clims/plugins/demo/models.py
@@ -17,6 +17,6 @@ class ExampleProject(ProjectBase):
     project_code = TextField("project_code")
 
 
-class Plate96(PlateBase):
-    rows = 8
-    columns = 12
+class PandorasBox(PlateBase):
+    rows = 3
+    columns = 3

--- a/src/clims/plugins/demo/models.py
+++ b/src/clims/plugins/demo/models.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
-from clims.services import SubstanceBase
+from clims.services.substance import SubstanceBase
 from clims.services.project import ProjectBase
 from clims.services.extensible import FloatField, TextField
+from clims.services.container import PlateBase
 
 
 class ExampleSample(SubstanceBase):
@@ -14,3 +15,8 @@ class ExampleSample(SubstanceBase):
 class ExampleProject(ProjectBase):
     pi = TextField("pi")
     project_code = TextField("project_code")
+
+
+class Plate96(PlateBase):
+    rows = 8
+    columns = 12

--- a/tests/clims/models/test_container.py
+++ b/tests/clims/models/test_container.py
@@ -109,7 +109,6 @@ class TestContainer(TestCase):
             in_original_order.append(sample)
             container.append(sample)
         container.save()
-        assert False
         assert container["A:1"].id == in_original_order[0].id
 
         container_fresh = self.app.containers.get_by_name(container.name)

--- a/tests/clims/models/test_container.py
+++ b/tests/clims/models/test_container.py
@@ -109,6 +109,7 @@ class TestContainer(TestCase):
             in_original_order.append(sample)
             container.append(sample)
         container.save()
+        assert False
         assert container["A:1"].id == in_original_order[0].id
 
         container_fresh = self.app.containers.get_by_name(container.name)


### PR DESCRIPTION
Purpose:
Place samples in containers (this seems to be lost during some refactoring?). Also, fix so that createexampledata can be run on its own, without being called within make fresh. There was a problem with plugin registration of the Demo plugin, and registration of Plate96.

Comments:
Maybe we could find something more general than Plate96?