### PR TITLE
Introduce the thread-local context

### DIFF
--- a/docs/deep-dive/extensible.md
+++ b/docs/deep-dive/extensible.md
@@ -1,8 +1,15 @@
 # Extensible types
 
-Common LIMS provides a way to extend any entity by a plugin. This is currently implemented only for `Substance` types, but support will be added for `Project` and `Container` too.
+Common LIMS provides a way to extend any entity by a plugin. The following core types are "Extensible":
 
-Data in extensible types is split into both the model for the actual business entity (e.g. `Substance`) as well as the `Extensible*` models:
+    Substance
+    Container
+    Project
+
+NOTE: Some of this is currently out-of-date
+NOTE: The name of extensible types might be changed in the future, since they are more than just extensible (they are also versioned and act in a context, see below).
+
+On the database level, Extensible types are split into both the model for the actual business entity (e.g. `Substance`) as well as the `Extensible*` models:
 
     * ExtensibleType
     * ExtensiblePropertyType
@@ -117,3 +124,14 @@ psql -d clims -c "select * from clims_extensibleproperty" \
 Notice how we got a new version in the property table where only the latest version is marked as latest.
 
 This design allows developers to easily write tools that show exactly what happened to a property. It's also simple to revert back to previous versions if required.
+
+## Context
+
+The extensible types are primarily written for use in plugins. The nature of plugins is that they are always executed in a certain `context`, which the plugin developer should not have to know too much about. The context provides access to the `ApplicationService`, which in turn gives access to every other service. It also knows about the organization it's being executed in and which user initated the action.
+
+This allows extensible types to provide a lot of logic without much setup. For example, creating this container in a handler will automatically set it in the correct context:
+
+    container = Container()
+    container.save()  # Organization is automatically added
+
+The context is implemented with thread local storage.

--- a/src/clims/api/endpoints/project.py
+++ b/src/clims/api/endpoints/project.py
@@ -36,7 +36,6 @@ class ProjectEndpoint(OrganizationEndpoint):
         project = self.app.extensibles.create(
             validated['name'],
             validated['type_full_name'],
-            organization,
             validated.get('properties', None))
         ret = {"id": project.id}
 

--- a/src/clims/api/endpoints/substance.py
+++ b/src/clims/api/endpoints/substance.py
@@ -36,7 +36,6 @@ class SubstanceEndpoint(OrganizationEndpoint):
         substance = self.app.extensibles.create(
             validated['name'],
             validated['type_full_name'],
-            organization,
             validated.get('properties', None))
         ret = {"id": substance.id}
 

--- a/src/clims/api/endpoints/substance_file.py
+++ b/src/clims/api/endpoints/substance_file.py
@@ -78,7 +78,7 @@ class SubstanceFileEndpoint(OrganizationEndpoint):
             return Response({'detail': 'File name must be specified'}, status=400)
 
         try:
-            org_file, issues = self.app.substances.load_file(organization, full_name, fileobj)
+            org_file, issues = self.app.substances.load_file(full_name, fileobj)
             issues_json = ValidationIssueSerializer(issues, many=True).data
             ret = dict(id=org_file.id, validationIssues=issues_json)
             return Response(ret, status=status.HTTP_201_CREATED)

--- a/src/clims/runner/commands/create_example_data.py
+++ b/src/clims/runner/commands/create_example_data.py
@@ -24,7 +24,7 @@ def createexampledata():
     org = Organization.objects.get(name="lab")
 
     from clims.plugins.demo import DemoPlugin
-    from clims.handlers import HandlerContext, CreateExampleDataHandler
+    from clims.handlers import CreateContext, CreateExampleDataHandler
 
     app.plugins.install_plugins(DemoPlugin)
     app.plugins.load_installed()
@@ -32,5 +32,6 @@ def createexampledata():
     # Now we'll run the handlers for all plugins (one of them being the DemoPlugin) for
     # creating example data. All plugins can plug into this behaviour by implementing the
     # CreateExampleDataHandler:
-    context = HandlerContext(organization=org)
-    app.plugins.handlers.handle(CreateExampleDataHandler, context, required=False)
+
+    with CreateContext(app, org, None) as context:
+        app.plugins.handlers.handle(CreateExampleDataHandler, context, required=False)

--- a/src/clims/services/container.py
+++ b/src/clims/services/container.py
@@ -239,14 +239,14 @@ class PlateBase(ContainerBase):
         table = to_table()
         longest = 0
         for row in table:
-            rows.append(map(format_fn, row))
+            rows.append([format_fn(r) if r else "" for r in row])
             longest = max(max(len(cell) for cell in rows[-1]), longest)
         for i in range(len(rows)):
             rows[i] = "|".join([cell.ljust(longest, " ") for cell in rows[i]])
 
         if header:
             rows.insert(0, self.name)
-        return "\n".join(map(six.text_type, rows))
+        return "\n".join([six.text_type(r) for r in rows])
 
 
 class ContainerService(BaseExtensibleService):

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -132,6 +132,7 @@ class Endpoint(APIView):
             return
 
     def initialize_request(self, request, *args, **kwargs):
+        logger.debug("Request initialized: {}, {}, {}".format(request, args, kwargs))
         rv = super(Endpoint, self).initialize_request(request, *args, **kwargs)
         # If our request is being made via our internal API client, we need to
         # stitch back on auth and user information

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -248,6 +248,11 @@ class OrganizationEndpoint(Endpoint):
             request.session['activeorg'] = organization.slug
 
         kwargs['organization'] = organization
+
+        # For now we're only setting the context if in an OrganizationEndpoint, not Endpoint
+        from clims.handlers import context_store
+        context_store.set(app=self.app, organization=organization, user=request.user)
+
         return (args, kwargs)
 
 

--- a/src/sentry/static/sentry/app/views/installWizard.jsx
+++ b/src/sentry/static/sentry/app/views/installWizard.jsx
@@ -99,7 +99,8 @@ export default class InstallWizard extends AsyncView {
       <div className="loading-error">
         <span className="icon-exclamation" />
         {t(
-          'We were unable to load the required configuration from the Sentry server. Please take a look at the service logs.'
+          'We were unable to load the required configuration from the Common LIMS server. ' +
+            'Please take a look at the service logs. (Clearing cookies may help if in devmode)'
         )}
       </div>
     );

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -83,18 +83,6 @@ class BaseTestCase(Fixtures, Exam):
         Hub.main.bind_client(None)
 
     @before
-    def setup_services(self):
-        # Set up clean service classes. This should ensure that each test case has a clean cache
-        # as caches should only be in services.
-        ioc.set_application(ApplicationService())
-
-        # NOTE: We'll have to reset the plugin manager so we don't get the plugins
-        # that have been loaded in scope. It would be better to never load those plugins in the
-        # first place, but that will be fixed when we stop using the global `plugins` object.
-        self.app = ioc.app
-        self.app.plugins.handlers.remove_implementations()
-
-    @before
     def setup_dummy_auth_provider(self):
         auth.register('dummy', DummyProvider)
         self.addCleanup(auth.unregister, 'dummy', DummyProvider)
@@ -112,6 +100,18 @@ class BaseTestCase(Fixtures, Exam):
     def initialize_log_level_for_toggle(self):
         self.log_level_toggled = False
         self.log_level_at_start = logging.getLogger().level
+
+    @before
+    def setup_services(self):
+        # Set up clean service classes. This should ensure that each test case has a clean cache
+        # as caches should only be in services.
+        ioc.set_application(ApplicationService())
+
+        # NOTE: We'll have to reset the plugin manager so we don't get the plugins
+        # that have been loaded in scope. It would be better to never load those plugins in the
+        # first place, but that will be fixed when we stop using the global `plugins` object.
+        self.app = ioc.app
+        self.app.plugins.handlers.remove_implementations()
 
     def set_log_level(self, lvl):
         logging.getLogger().setLevel(lvl)

--- a/tests/clims/api/endpoints/test_container.py
+++ b/tests/clims/api/endpoints/test_container.py
@@ -11,6 +11,9 @@ from tests.fixtures.plugins.gemstones_inc.models import GemstoneSample, Gemstone
 
 
 class ContainerTest(APITestCase):
+    def setUp(self):
+        self.has_context()
+
     def test_find_single_container_by_container_name(self):
         # TODO: This takes too much time for 10 containers filled with samples
         container = self.create_container_with_samples(

--- a/tests/clims/api/endpoints/test_container_property.py
+++ b/tests/clims/api/endpoints/test_container_property.py
@@ -7,6 +7,8 @@ from tests.fixtures.plugins.gemstones_inc.models import GemstoneContainer
 
 
 class ContainerPropertyEndpointTest(APITestCase):
+    def setUp(self):
+        self.has_context()
 
     def test_find_all_container_property(self):
         container = self.create_container(color='blue', klass=GemstoneContainer)

--- a/tests/clims/api/endpoints/test_project_property.py
+++ b/tests/clims/api/endpoints/test_project_property.py
@@ -8,6 +8,8 @@ from tests.fixtures.plugins.gemstones_inc.models import GemstoneProject
 
 
 class ProjectPropertyEndpointTest(APITestCase):
+    def setUp(self):
+        self.has_context()
 
     def test_find_all_substance_property(self):
 

--- a/tests/clims/api/endpoints/test_projects.py
+++ b/tests/clims/api/endpoints/test_projects.py
@@ -14,6 +14,8 @@ from tests.fixtures.plugins.gemstones_inc.models import GemstoneProject
 
 
 class ProjectTest(APITestCase):
+    def setUp(self):
+        self.has_context()
 
     def test_search_project_find_single_by_name(self):
         # NOTE: For now, the search is always using wildcards. This will be ported to using

--- a/tests/clims/api/endpoints/test_substance_property.py
+++ b/tests/clims/api/endpoints/test_substance_property.py
@@ -8,6 +8,9 @@ from tests.fixtures.plugins.gemstones_inc.models import GemstoneSample
 
 
 class SubstancePropertyEndpointTest(APITestCase):
+    def setUp(self):
+        self.has_context()
+
     def create_gemstone(self, *args, **kwargs):
         return self.create_substance(GemstoneSample, *args, **kwargs)
 

--- a/tests/clims/api/endpoints/test_substances.py
+++ b/tests/clims/api/endpoints/test_substances.py
@@ -13,6 +13,9 @@ from tests.fixtures.plugins.gemstones_inc.models import GemstoneSample
 
 
 class SubstancesTest(APITestCase):
+    def setUp(self):
+        self.has_context()
+
     def create_gemstone(self, *args, **kwargs):
         return self.create_substance(GemstoneSample, *args, **kwargs)
 

--- a/tests/clims/api/serializers/models/test_substance.py
+++ b/tests/clims/api/serializers/models/test_substance.py
@@ -7,6 +7,10 @@ from clims.api.serializers.models.substance import SubstanceSerializer
 
 
 class SubstanceSerializerTest(SubstanceTestCase):
+    def setUp(self):
+        # TODO: It would be better if the serializer tests wouldn't require a context
+        self.has_context()
+
     def test_simple(self):
         sample = self.create_gemstone(color='red')
         serializer = SubstanceSerializer(sample)

--- a/tests/clims/models/test_container.py
+++ b/tests/clims/models/test_container.py
@@ -16,27 +16,28 @@ class TestContainer(TestCase):
     def setUp(self):
         self.register_extensible(HairSampleContainer)
         self.register_extensible(HairSample)
+        self.has_context()
 
     def test_can_register_container(self):
         self.register_extensible(HairSampleContainer)
 
     def test_can_create_container(self):
         self.register_extensible(HairSampleContainer)
-        container = HairSampleContainer(name="container1", organization=self.organization)
+        container = HairSampleContainer(name="container1")
         container.save()
         Container.objects.get(name=container.name)  # Raises DoesNotExist if it wasn't created
 
     def test_name_is_unique(self):
         self.register_extensible(HairSampleContainer)
-        container = HairSampleContainer(name="container1", organization=self.organization)
+        container = HairSampleContainer(name="container1")
         container.save()
-        container2 = HairSampleContainer(name=container.name, organization=self.organization)
+        container2 = HairSampleContainer(name=container.name)
         with pytest.raises(IntegrityError):
             container2.save()
 
     def test_can_add_custom_property(self):
         self.register_extensible(HairSampleContainer)
-        container = HairSampleContainer(name="container1", organization=self.organization)
+        container = HairSampleContainer(name="container1")
         container.comment = "test"
         container.save()
 
@@ -47,12 +48,12 @@ class TestContainer(TestCase):
         self.register_extensible(HairSampleContainer)
         self.register_extensible(HairSample)
 
-        sample = HairSample(name="sample1", organization=self.organization)
+        sample = HairSample(name="sample1")
         sample.length = 10
         sample.width = 20
 
         from clims.models import Substance
-        container = HairSampleContainer(name="container1", organization=self.organization)
+        container = HairSampleContainer(name="container1")
         container.comment = "This container is great and live is awesome"
         container["A1"] = sample
 
@@ -68,7 +69,7 @@ class TestContainer(TestCase):
         self.register_extensible(HairSampleContainer)
         self.register_extensible(HairSample)
 
-        container = HairSampleContainer(name="cont1", organization=self.organization)
+        container = HairSampleContainer(name="cont1")
         by_row = list(container._traverse(HairSampleContainer.TRAVERSE_BY_ROW))
         by_col = list(container._traverse(HairSampleContainer.TRAVERSE_BY_COLUMN))
 
@@ -86,11 +87,9 @@ class TestContainer(TestCase):
         self.register_extensible(HairSampleContainer)
         self.register_extensible(HairSample)
 
-        container = HairSampleContainer(name="cont-{}".format(uuid.uuid4()),
-                organization=self.organization)
+        container = HairSampleContainer(name="cont-{}".format(uuid.uuid4()))
 
-        container["A:1"] = HairSample(name="sample-{}".format(container.name),
-                organization=self.organization)
+        container["A:1"] = HairSample(name="sample-{}".format(container.name))
         container.save()
         assert container[(0, 0)] == container["A:1"]
 
@@ -100,12 +99,11 @@ class TestContainer(TestCase):
         # HairSampleContainer doesn't override the default, it uses TRAVERSE_BY_COLUMN, i.e. it
         # fills a column before it goes to the next column.
 
-        container = HairSampleContainer(name="cont-{}".format(uuid.uuid4()), organization=self.organization)
+        container = HairSampleContainer(name="cont-{}".format(uuid.uuid4()))
 
         in_original_order = list()
         for ix in range(2):
-            sample = HairSample(name="sample-{}-{}".format(container.name, ix),
-                    organization=self.organization)
+            sample = HairSample(name="sample-{}-{}".format(container.name, ix))
             in_original_order.append(sample)
             container.append(sample)
         container.save()
@@ -117,12 +115,10 @@ class TestContainer(TestCase):
     def test_can_output_default_string_info(self):
         # One should be able to get a detailed text version of the container for debugging
         # and demoing.
-        container = HairSampleContainer(name="cont-{}".format(uuid.uuid4()),
-                organization=self.organization)
+        container = HairSampleContainer(name="cont-{}".format(uuid.uuid4()))
 
         for ix in range(container.rows):
-            sample = HairSample(name="sample-{}-{}".format(container.name, ix),
-                    organization=self.organization)
+            sample = HairSample(name="sample-{}-{}".format(container.name, ix))
             container.append(sample)
         container.save()
 

--- a/tests/clims/models/test_project.py
+++ b/tests/clims/models/test_project.py
@@ -13,21 +13,22 @@ class TestProject(TestCase):
     def setUp(self):
         self.register_extensible(VampireFangStudyProject)
         self.register_extensible(VampireFangSample)
+        self.has_context()
 
     def test_can_create_project(self):
-        project = VampireFangStudyProject(name="project1", organization=self.organization)
+        project = VampireFangStudyProject(name="project1")
         project.save()
         self.app.projects.get(name=project.name)  # Raises DoesNotExist if it wasn't created
 
     def test_name_is_unique(self):
-        project = VampireFangStudyProject(name="project1", organization=self.organization)
+        project = VampireFangStudyProject(name="project1")
         project.save()
-        project2 = VampireFangStudyProject(name=project.name, organization=self.organization)
+        project2 = VampireFangStudyProject(name=project.name)
         with pytest.raises(IntegrityError):
             project2.save()
 
     def test_can_add_custom_property(self):
-        project = VampireFangStudyProject(name="project1", organization=self.organization)
+        project = VampireFangStudyProject(name="project1")
         project.comment = "test"
         project.save()
 
@@ -35,45 +36,45 @@ class TestProject(TestCase):
         assert project.comment == project_fetched_again.comment
 
     def test_can_add_sample(self):
-        project = VampireFangStudyProject(name="project1", organization=self.organization)
+        project = VampireFangStudyProject(name="project1")
         project.save()
-        sample = VampireFangSample(name="sample1", organization=self.organization, project=project)
+        sample = VampireFangSample(name="sample1", project=project)
         sample.pointiness = 10.0
         sample.save()
         assert sample.project.name == project.name
 
     def test_project_type(self):
-        project = VampireFangStudyProject(name="project1", organization=self.organization)
+        project = VampireFangStudyProject(name="project1")
         project.save()
-        sample = VampireFangSample(name="sample1", organization=self.organization, project=project)
+        sample = VampireFangSample(name="sample1", project=project)
         sample.pointiness = 10.0
         sample.save()
         assert isinstance(sample.project, VampireFangStudyProject)
 
     @pytest.mark.skip('not implemented')
     def test_save_two_samples__with_same_names_but_different_projects__ok(self):
-        project1 = VampireFangStudyProject(name="project1", organization=self.organization)
+        project1 = VampireFangStudyProject(name="project1")
         project1.save()
-        sample1 = VampireFangSample(name="sample1", organization=self.organization, project=project1)
+        sample1 = VampireFangSample(name="sample1", project=project1)
         sample1.pointiness = 10.0
         sample1.save()
 
-        project2 = VampireFangStudyProject(name="project2", organization=self.organization)
+        project2 = VampireFangStudyProject(name="project2")
         project2.save()
-        sample1b = VampireFangSample(name="sample1", organization=self.organization, project=project2)
+        sample1b = VampireFangSample(name="sample1", project=project2)
         sample1b.pointiness = 10.0
         sample1b.save()
 
     def test_sample_is_not_initalized_with_project__project_on_sample_is_none(self):
-        sample1 = VampireFangSample(name="sample1", organization=self.organization)
+        sample1 = VampireFangSample(name="sample1")
         sample1.pointiness = 10.0
         sample1.save()
         assert sample1.project is None
 
     def test_create_and_save_sample__with_project_set__fetched_sample_from_db_has_project(self):
-        project = VampireFangStudyProject(name="project1", organization=self.organization)
+        project = VampireFangStudyProject(name="project1")
         project.save()
-        sample = VampireFangSample(name="sample1", organization=self.organization, project=project)
+        sample = VampireFangSample(name="sample1", project=project)
         sample.pointiness = 10.0
         sample.save()
         fetched_sample = self.app.substances.get(name='sample1')

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -29,6 +29,7 @@ class SubstancePropertiesTestCase(TestCase):
 
     def setUp(self):
         self.register_extensible(self.ExampleSample)
+        self.has_context()
 
     def test_can_create_substance_with_properties(self):
         moxy = random.randint(1, 100)
@@ -37,7 +38,6 @@ class SubstancePropertiesTestCase(TestCase):
 
         name = "sample-{}".format(random.randint(1, 1000000))
         sample = self.ExampleSample(name=name,
-                                    organization=self.organization,
                                     moxy=moxy,
                                     cool=cool,
                                     erudite=erudite)
@@ -55,7 +55,6 @@ class SubstancePropertiesTestCase(TestCase):
 
         name = "sample-{}".format(random.randint(1, 1000000))
         sample = self.ExampleSample(name=name,
-                                    organization=self.organization,
                                     moxy=moxy,
                                     cool=cool,
                                     erudite=erudite)
@@ -71,7 +70,6 @@ class SubstancePropertiesTestCase(TestCase):
         erudite = random.randint(1, 100)
 
         sample = self.ExampleSample(name=name,
-                                    organization=self.organization,
                                     moxy=None,
                                     cool=cool,
                                     erudite=erudite)
@@ -88,13 +86,15 @@ class SubstancePropertiesTestCase(TestCase):
 
         with pytest.raises(ExtensibleTypeValidationError):
             self.ExampleSample(name=name,
-                               organization=self.organization,
                                moxy=None,
                                cool=cool,
                                erudite=None)
 
 
 class TestSubstance(SubstanceTestCase):
+    def setUp(self):
+        self.has_context()
+
     def test_can_create_substance(self):
         substance = self.create_gemstone()
         assert substance.version == 1
@@ -161,7 +161,7 @@ class TestSubstance(SubstanceTestCase):
 
         # Act
         combined = GemstoneSample(
-            name='combined1', organization=self.organization,
+            name='combined1',
             parents=[child1, child2])
         combined.save()
 
@@ -177,7 +177,7 @@ class TestSubstance(SubstanceTestCase):
 
         # Act
         combined = GemstoneSample(
-            name='combined1', organization=self.organization,
+            name='combined1',
             parents=[substance1, substance2])
         combined.preciousness = 'xxx'
         combined.save()
@@ -199,7 +199,7 @@ class TestSubstance(SubstanceTestCase):
 
         # Act
         combined = GemstoneSample(
-            name='combined1', organization=self.organization,
+            name='combined1',
             parents=[substance1, substance2])
         combined.save()
 

--- a/tests/clims/models/test_substance_child.py
+++ b/tests/clims/models/test_substance_child.py
@@ -5,6 +5,9 @@ from tests.clims.models.test_substance import SubstanceTestCase
 
 
 class TestSubstanceParentChild(SubstanceTestCase):
+    def setUp(self):
+        self.has_context()
+
     def test_can_find_parent_from_child(self):
         sample = self.create_gemstone()
         child = sample.create_child()

--- a/tests/clims/models/test_substance_visualize.py
+++ b/tests/clims/models/test_substance_visualize.py
@@ -4,6 +4,9 @@ from tests.clims.models.test_substance import SubstanceTestCase
 
 
 class TestSubstance(SubstanceTestCase):
+    def setUp(self):
+        self.has_context()
+
     def test_can_render_substance_graph(self):
         sample1 = self.create_gemstone()  # sample1.v1
         original_id = sample1.id

--- a/tests/clims/services/test_projects.py
+++ b/tests/clims/services/test_projects.py
@@ -10,6 +10,7 @@ class TestProjectService(TestCase):
 
     def setUp(self):
         self.register_extensible(GemstoneProject)
+        self.has_context()
 
     def create_a_bunch_of_projects(self):
         country_choices = ['Sweden', 'Norway', 'Denmark', 'Finland', 'Flat Iceland']
@@ -17,7 +18,6 @@ class TestProjectService(TestCase):
         for i in range(0, 100):
             pick = random.choice(country_choices)
             project = GemstoneProject(name='project{}'.format(i),
-                                      organization=self.organization,
                                       country_of_sampling=pick)
             project.save()
             country_list.append(pick)

--- a/tests/clims/services/test_substances.py
+++ b/tests/clims/services/test_substances.py
@@ -43,6 +43,7 @@ class TestGemstoneSampleSubmission(SubstanceTestCase):
 
         # TODO: It would be cleaner to have the plugins instance in the ApplicationService
         self.app.plugins.handlers.add_handler_implementation(SubstancesSubmissionHandler, MyHandler)
+        self.has_context()
 
     def test_run_gemstone_sample_submission_handler__with_csv__6_samples_found_in_db(self):
         # Arrange
@@ -50,7 +51,7 @@ class TestGemstoneSampleSubmission(SubstanceTestCase):
         fileobj = StringIO.StringIO(content)
 
         # Act
-        self.app.substances.load_file(self.organization, "the_file.csv", fileobj)
+        self.app.substances.load_file("the_file.csv", fileobj)
 
         # Assert
         all_samples = Substance.objects.all()
@@ -72,7 +73,7 @@ class TestGemstoneSampleSubmission(SubstanceTestCase):
         fileobj = BytesIO(contents)
 
         # Act
-        self.app.substances.load_file(self.organization, "the_file.xlsx", fileobj)
+        self.app.substances.load_file("the_file.xlsx", fileobj)
 
         # Assert
         all_samples = Substance.objects.all()
@@ -89,18 +90,19 @@ class TestSubstanceService(TestCase):
     def setUp(self):
         self.register_extensible(GemstoneProject)
         self.register_extensible(GemstoneSample)
+        self.has_context()
 
     def test_get_substances_by_project__with_2_samples_in_project_and_1_outside__2_hits(self):
         # Arrange
-        project1 = GemstoneProject(name='project1', organization=self.organization)
+        project1 = GemstoneProject(name='project1')
         project1.save()
-        project2 = GemstoneProject(name='project2', organization=self.organization)
+        project2 = GemstoneProject(name='project2')
         project2.save()
-        sample1 = GemstoneSample(name='sample1', organization=self.organization, project=project1)
+        sample1 = GemstoneSample(name='sample1', project=project1)
         sample1.save()
-        sample2 = GemstoneSample(name='sample2', organization=self.organization, project=project1)
+        sample2 = GemstoneSample(name='sample2', project=project1)
         sample2.save()
-        sample3 = GemstoneSample(name='sample3', organization=self.organization, project=project2)
+        sample3 = GemstoneSample(name='sample3', project=project2)
         sample3.save()
 
         # Act
@@ -112,15 +114,15 @@ class TestSubstanceService(TestCase):
 
     def test_filter_substances_by_project_name__with_2_samples_in_project_and_1_outside__2_hits(self):
         # Arrange
-        project1 = GemstoneProject(name='project1', organization=self.organization)
+        project1 = GemstoneProject(name='project1')
         project1.save()
-        project2 = GemstoneProject(name='project2', organization=self.organization)
+        project2 = GemstoneProject(name='project2')
         project2.save()
-        sample1 = GemstoneSample(name='sample1', organization=self.organization, project=project1)
+        sample1 = GemstoneSample(name='sample1', project=project1)
         sample1.save()
-        sample2 = GemstoneSample(name='sample2', organization=self.organization, project=project1)
+        sample2 = GemstoneSample(name='sample2', project=project1)
         sample2.save()
-        sample3 = GemstoneSample(name='sample3', organization=self.organization, project=project2)
+        sample3 = GemstoneSample(name='sample3', project=project2)
         sample3.save()
 
         # Act
@@ -132,9 +134,9 @@ class TestSubstanceService(TestCase):
 
     def test_filter_substance_by_project_name__with_only_1_sample__sample_property_works(self):
         # Arrange
-        project1 = GemstoneProject(name='project1', organization=self.organization)
+        project1 = GemstoneProject(name='project1')
         project1.save()
-        sample1 = GemstoneSample(name='sample1', organization=self.organization, project=project1)
+        sample1 = GemstoneSample(name='sample1', project=project1)
         sample1.color = 'red'
         sample1.save()
 
@@ -146,13 +148,13 @@ class TestSubstanceService(TestCase):
         assert fetched_samples[0].color == 'red'
 
     def create_a_bunch_of_sample(self):
-        project1 = GemstoneProject(name='project1', organization=self.organization)
+        project1 = GemstoneProject(name='project1')
         project1.save()
 
         color_choices = set(['red', 'blue', 'green'])
         color_list = []
         for i in range(0, 100):
-            sample = GemstoneSample(name='sample{}'.format(i), organization=self.organization, project=project1)
+            sample = GemstoneSample(name='sample{}'.format(i), project=project1)
             color_pick = random.choice(list(color_choices))
             color_list.append(color_pick)
             sample.color = color_pick
@@ -189,7 +191,7 @@ class MyHandler(SubstancesSubmissionHandler):
         csv = self._as_csv(multi_format_file)
         for line in csv:
             name = line['Sample ID']
-            sample = GemstoneSample(name=name, organization=self.context.organization)
+            sample = GemstoneSample(name=name)
             sample.preciousness = line['Preciousness']
             sample.color = line['Color']
             sample.save()


### PR DESCRIPTION
One of the main goals of Common LIMS is to provide a very simple way to
extend the system. The most basic way to extend the system is in plugin
handlers. The plugin dev should have the power to do everything, but it
should be simple, at least in most cases.

On of the pieces of that design is the thread-local context. Until now
we've just had the "context", which is the same thing but I waited with
implementing this part of it, which is how objects share the context.

The context has:
- the application service, from which all other services can be derived
- the organization
- the current user
(more things may come)

When a handler executes, a context has already been started for the
user. It effectively enhances the business object, because they now have
access to everything the plugin dev requires, without the dev having to
initialize the objects with that data. This means that the user can do
this:

    sample = OurSample(name="testname")
    sample.save()

and it will work, even if they didn't add any other required info, such
as the user or the organization.

A very similar approach *would* have been allowing the user only to
create objects through a factory, e.g.:

    sample = self.OurSample(name="testname")

but since one of the core goals of the plugin system is readability, I
chose the previous approach.

This approach is similar to Django's atomic db transactions, which can be started with
e.g. `with transaction.atomic()`. Django transactions do also use thread local storage to
communicate data between different parts of the code.