### PR TITLE
clims-351, fix create example data

### DIFF
--- a/src/clims/plugins/demo/dnaseq/handlers/create_example_data.py
+++ b/src/clims/plugins/demo/dnaseq/handlers/create_example_data.py
@@ -4,7 +4,7 @@ import logging
 from uuid import uuid4
 
 from clims.handlers import CreateExampleDataHandler
-from ..models import ExampleSample, ExampleProject
+from ..models import ExampleSample, ExampleProject, PandorasBox
 
 
 logger = logging.getLogger(__name__)
@@ -17,9 +17,7 @@ class DemoCreateExampleDataHandler(CreateExampleDataHandler):
 
         Any plugin that implements this handler will supply demo data
         """
-
         logger.info("Creating example data for the builtin Demo plugin")
-
         created = True
         try:
             self.app.substances.get(name="demoplugin-sample-1")
@@ -30,9 +28,25 @@ class DemoCreateExampleDataHandler(CreateExampleDataHandler):
             logger.info("Demo data has already been imported")
             return
 
-        available_sample_types = ["Vampire Fang", "Zombie Brain", "Hydra Claw"]
+        available_containers = []
         for ix in range(100):
-            name = "demoplugin-sample-{}".format(ix + 1)
+            id = ix + 1
+            # id = uuid4().hex
+            name = 'pandora-{}'.format(id)
+            try:
+                container = self.app.containers.get(name=name)
+                logger.info('Container already exists, fetched from db: {}'.format(container.name))
+            except self.app.containers.DoesNotExist:
+                container = PandorasBox(name=name, organization=self.context.organization)
+                container.save()
+                logger.info('Created container: {}'.format(container.name))
+            available_containers.append(container)
+
+        available_sample_types = ["Vampire Fang", "Zombie Brain", "Hydra Claw"]
+        for _ix in range(100):
+            # id = ix + 1
+            id = random.randint(1, 10000000)
+            name = "demoplugin-sample-{}".format(id)
             sample = ExampleSample(name=name,
                                    moxy=random.randint(1, 100),
                                    cool=random.randint(1, 100),
@@ -40,6 +54,14 @@ class DemoCreateExampleDataHandler(CreateExampleDataHandler):
                                    sample_type=random.choice(available_sample_types))
             sample.save()
             logger.info("Created sample: {}".format(sample.name))
+            plate = random.choice(available_containers)
+            if not sample.location and len(plate.contents) < plate.rows * plate.columns:
+                plate.append(sample)
+                sample.save()
+                logger.info("Appended sample: {}".format(sample.name))
+
+        for plate in available_containers:
+            plate.save()
 
         pis = ["Rosalind Franklin", "Charles Darwin", "Gregor Mendel"]
         for _ in range(100):

--- a/src/clims/plugins/demo/dnaseq/handlers/create_example_data.py
+++ b/src/clims/plugins/demo/dnaseq/handlers/create_example_data.py
@@ -37,7 +37,7 @@ class DemoCreateExampleDataHandler(CreateExampleDataHandler):
                 container = self.app.containers.get(name=name)
                 logger.info('Container already exists, fetched from db: {}'.format(container.name))
             except self.app.containers.DoesNotExist:
-                container = PandorasBox(name=name, organization=self.context.organization)
+                container = PandorasBox(name=name)
                 container.save()
                 logger.info('Created container: {}'.format(container.name))
             available_containers.append(container)
@@ -55,7 +55,7 @@ class DemoCreateExampleDataHandler(CreateExampleDataHandler):
             sample.save()
             logger.info("Created sample: {}".format(sample.name))
             plate = random.choice(available_containers)
-            if not sample.location and len(plate.contents) < plate.rows * plate.columns:
+            if not sample.location and len(list(plate.contents)) < plate.rows * plate.columns:
                 plate.append(sample)
                 sample.save()
                 logger.info("Appended sample: {}".format(sample.name))

--- a/src/clims/plugins/demo/dnaseq/models.py
+++ b/src/clims/plugins/demo/dnaseq/models.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
-from clims.services import SubstanceBase, PlateBase
+from clims.services.substance import SubstanceBase
 from clims.services.project import ProjectBase
 from clims.services.extensible import FloatField, TextField
+from clims.services.container import PlateBase
 
 
 class ExampleSample(SubstanceBase):
@@ -21,3 +22,8 @@ class ExamplePlate(PlateBase):
 class ExampleProject(ProjectBase):
     pi = TextField("pi")
     project_code = TextField("project_code")
+
+
+class PandorasBox(PlateBase):
+    rows = 3
+    columns = 3

--- a/src/clims/services/container.py
+++ b/src/clims/services/container.py
@@ -16,7 +16,7 @@ class ContainerIndex(object):
     Represent an index into a regular Container.
     """
 
-    def __init__(self, x, y, z):
+    def __init__(self, x=None, y=None, z=None):
         self.x = x
         self.y = y
         self.z = z

--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -21,7 +21,7 @@ class ExtensibleService(object):
     def __init__(self, app):
         self._app = app
         self._model_cache = dict()
-        self._implementations = dict()
+        self._implementations = None
         self._logger = logging.getLogger(self.__class__.__name__)
 
     def clear_cache(self):
@@ -97,6 +97,8 @@ class ExtensibleService(object):
         """
         This is for testing purposes only!
         """
+        # trigger initiation of the implementation array
+        self.implementations
         name = '{}.{}'.format(extensible_base.__module__, extensible_base.__name__)
         del(self._implementations[name])
 

--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -87,6 +87,13 @@ class ExtensibleService(object):
                                                property_types=property_types)
         return extensible_type
 
+    def unregister_model(self, extensible_base, plugin):
+        """
+        This is for testing purposes only!
+        """
+        name = '{}.{}'.format(extensible_base.__module__, extensible_base.__name__)
+        del(self._implementations[name])
+
     @transaction.atomic
     def _register_model(self, name, org, plugin, property_types=None):
         """

--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -20,8 +20,8 @@ class ExtensibleTypeNotRegistered(Exception):
 class ExtensibleService(object):
     def __init__(self, app):
         self._app = app
-        self._implementations = dict()
         self._model_cache = dict()
+        self._implementations = dict()
         self._logger = logging.getLogger(self.__class__.__name__)
 
     def clear_cache(self):
@@ -44,7 +44,7 @@ class ExtensibleService(object):
 
     def get_implementation(self, extensible_type_full_name):
         try:
-            return self._implementations[extensible_type_full_name]
+            return self.implementations[extensible_type_full_name]
         except KeyError:
             raise ExtensibleTypeNotRegistered(extensible_type_full_name)
 
@@ -62,6 +62,16 @@ class ExtensibleService(object):
                     "The type '{}' is not registered".format(name))
         return self._model_cache[name]
 
+    @property
+    def implementations(self):
+        if not self._implementations:
+            extensible_types = self._app.plugins.get_extensible_types_from_db()
+            self._implementations = dict()
+            for ext_class in extensible_types:
+                full_name = '{}.{}'.format(ext_class.__module__, ext_class.__name__)
+                self._implementations[full_name] = ext_class
+        return self._implementations
+
     def register(self, plugin_reg, extensible_base):
         logger.info("Installing '{}' from plugin '{}@{}'".format(
             utils.class_full_name(extensible_base), plugin_reg.name,
@@ -78,13 +88,9 @@ class ExtensibleService(object):
                 display_name=field.display_name)
             property_types.append(prop_type)
 
-        name = "{}.{}".format(extensible_base.__module__,
-                              extensible_base.__name__)
-        self._implementations[name] = extensible_base
-        extensible_type = self._register_model(name,
-                                               'default',
-                                               plugin_reg,
-                                               property_types=property_types)
+        name = "{}.{}".format(extensible_base.__module__, extensible_base.__name__)
+        extensible_type = self._register_model(
+            name, 'default', plugin_reg, property_types=property_types)
         return extensible_type
 
     def unregister_model(self, extensible_base, plugin):

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -193,6 +193,8 @@ class SubstanceBase(HasLocationMixin, ExtensibleBase):
         # when looping samples in a container, the very same container is fetched over and
         # over again
         loc = self.location
+        if loc is None:
+            return None
         container = self._app.containers.to_wrapper(loc.container)
         container_index_class = container.IndexType
         # Can we assume that container index class has only row and column, not z?

--- a/src/sentry/plugins/base/manager.py
+++ b/src/sentry/plugins/base/manager.py
@@ -141,9 +141,9 @@ class PluginManager(object):
         extensible_types = ExtensibleType.objects.all()
         type_names_in_db = [e.name for e in extensible_types]
         for type_name in type_names_in_db:
-            splitted = type_name.split('.')
-            full_module_name = '.'.join(splitted[:-1])
-            extensible_class_name = splitted[-1]
+            split_type_name = type_name.split('.')
+            full_module_name = '.'.join(split_type_name[:-1])
+            extensible_class_name = split_type_name[-1]
             module = self._import_module(full_module_name)
             extensible_class = getattr(module, extensible_class_name, None)
             yield extensible_class
@@ -370,8 +370,8 @@ class PluginManager(object):
         return self._import_module(full_module_name)
 
     def _import_module(self, full_module_name):
-        splitted = full_module_name.split('.')
-        name = splitted[-1]
+        split_name = full_module_name.split('.')
+        name = split_name[-1]
         try:
             return importlib.import_module(full_module_name)
         except ImportError as ex:

--- a/tests/clims/api/endpoints/test_substances.py
+++ b/tests/clims/api/endpoints/test_substances.py
@@ -60,12 +60,15 @@ class SubstancesTest(APITestCase):
             properties = response.pop('properties')
             if 'color' in properties:
                 assert properties['color']['value'] == sample.properties['color'].value
-            assert response == dict(name=sample.name,
-                    version=sample.version,
-                    id=sample.id,
-                    type_full_name=sample.type_full_name,
-                    location=None,
-                    global_id="Substance-{}".format(sample.id))
+            assert response == dict(
+                name=sample.name,
+                version=sample.version,
+                id=sample.id,
+                type_full_name=sample.type_full_name,
+                location=None,
+                global_id="Substance-{}".format(sample.id),
+                container_index=None,
+            )
 
         asserts(first, data_by_id[first.id])
         asserts(second, data_by_id[second.id])

--- a/tests/clims/models/test_container.py
+++ b/tests/clims/models/test_container.py
@@ -132,11 +132,9 @@ class TestContainer(TestCase):
         assert re.match(r"^\d+[ |].+", first_line) is not None
 
     def test_get_container_from_sample__when_container_is_unregisterred__container_reference_still_works(self):
-        container = HairSampleContainer(name="cont-{}".format(uuid.uuid4()),
-                                        organization=self.organization)
+        container = HairSampleContainer(name="cont-{}".format(uuid.uuid4()))
 
-        sample = HairSample(name="sample-{}-{}".format(container.name, uuid.uuid4()),
-                            organization=self.organization)
+        sample = HairSample(name="sample-{}-{}".format(container.name, uuid.uuid4()))
         # container.append(sample)
         container['B2'] = sample
         container.save()

--- a/tests/clims/models/test_container.py
+++ b/tests/clims/models/test_container.py
@@ -131,6 +131,27 @@ class TestContainer(TestCase):
         # Expecting a digit followed by some empty columns:
         assert re.match(r"^\d+[ |].+", first_line) is not None
 
+    def test_get_container_from_sample__when_container_is_unregisterred__container_reference_still_works(self):
+        container = HairSampleContainer(name="cont-{}".format(uuid.uuid4()),
+                                        organization=self.organization)
+
+        sample = HairSample(name="sample-{}-{}".format(container.name, uuid.uuid4()),
+                            organization=self.organization)
+        # container.append(sample)
+        container['B2'] = sample
+        container.save()
+        self.app.extensibles.unregister_model(HairSampleContainer, self.create_plugin())
+        fresh_sample = self.app.substances.get_by_name(sample.name)
+
+        # Act
+        container_index = fresh_sample.container_index
+
+        # Assert
+
+        assert container_index.x == 1
+        assert container_index.y == 1
+        assert container_index.z is None
+
     # TODO: Test that ensures that all samples have the container, perhaps
     # reusing the container domain object if in the same context (e.g. in a handler)
 

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -22,14 +22,8 @@ class SubstanceTestCase(TestCase):
 
 
 class SubstancePropertiesTestCase(TestCase):
-
-    class ExampleSample(SubstanceBase):
-        moxy = FloatField("moxy")
-        cool = FloatField("cool")
-        erudite = FloatField("erudite", nullable=False)
-
     def setUp(self):
-        self.register_extensible(self.ExampleSample)
+        self.register_extensible(ExampleSample)
         self.has_context()
 
     def test_can_create_substance_with_properties(self):
@@ -38,10 +32,10 @@ class SubstancePropertiesTestCase(TestCase):
         erudite = random.randint(1, 100)
 
         name = "sample-{}".format(random.randint(1, 1000000))
-        sample = self.ExampleSample(name=name,
-                                    moxy=moxy,
-                                    cool=cool,
-                                    erudite=erudite)
+        sample = ExampleSample(name=name,
+                               moxy=moxy,
+                               cool=cool,
+                               erudite=erudite)
         sample.save()
 
         fetched_sample = self.app.substances.get(name=sample.name)
@@ -55,10 +49,10 @@ class SubstancePropertiesTestCase(TestCase):
         erudite = random.randint(1, 100)
 
         name = "sample-{}".format(random.randint(1, 1000000))
-        sample = self.ExampleSample(name=name,
-                                    moxy=moxy,
-                                    cool=cool,
-                                    erudite=erudite)
+        sample = ExampleSample(name=name,
+                               moxy=moxy,
+                               cool=cool,
+                               erudite=erudite)
         sample.save()
 
         assert sample.moxy == moxy
@@ -70,10 +64,10 @@ class SubstancePropertiesTestCase(TestCase):
         cool = random.randint(1, 100)
         erudite = random.randint(1, 100)
 
-        sample = self.ExampleSample(name=name,
-                                    moxy=None,
-                                    cool=cool,
-                                    erudite=erudite)
+        sample = ExampleSample(name=name,
+                               moxy=None,
+                               cool=cool,
+                               erudite=erudite)
         sample.save()
 
         fetched_sample = self.app.substances.get(name=sample.name)
@@ -86,10 +80,10 @@ class SubstancePropertiesTestCase(TestCase):
         cool = random.randint(1, 100)
 
         with pytest.raises(ExtensibleTypeValidationError):
-            self.ExampleSample(name=name,
-                               moxy=None,
-                               cool=cool,
-                               erudite=None)
+            ExampleSample(name=name,
+                          moxy=None,
+                          cool=cool,
+                          erudite=None)
 
 
 class TestSubstance(SubstanceTestCase):
@@ -437,6 +431,12 @@ class TestSubstance(SubstanceTestCase):
 
         # Assert
         assert container_index is None
+
+
+class ExampleSample(SubstanceBase):
+    moxy = FloatField("moxy")
+    cool = FloatField("cool")
+    erudite = FloatField("erudite", nullable=False)
 
 
 class QuirkSample(SubstanceBase):

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import random
 import pytest
+import uuid
 from sentry.testutils import TestCase
 from clims.models import Substance, SubstanceVersion
 from clims.services import ExtensibleTypeValidationError
@@ -424,6 +425,18 @@ class TestSubstance(SubstanceTestCase):
         squirkyness = extensible_type.property_types.get(name='squirkyness')
 
         assert squirkyness.display_name == 'The Squirkyness Display Value'
+
+    def test__with_sample_has_no_container__container_index_returns_none(self):
+        # Arrange
+        self.register_extensible(QuirkSample)
+        sample = QuirkSample(
+            name='sample-{}'.format(uuid.uuid4()), organization=self.organization)
+
+        # Act
+        container_index = sample.container_index
+
+        # Assert
+        assert container_index is None
 
 
 class QuirkSample(SubstanceBase):

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -424,7 +424,7 @@ class TestSubstance(SubstanceTestCase):
         # Arrange
         self.register_extensible(QuirkSample)
         sample = QuirkSample(
-            name='sample-{}'.format(uuid.uuid4()), organization=self.organization)
+            name='sample-{}'.format(uuid.uuid4()))
 
         # Act
         container_index = sample.container_index


### PR DESCRIPTION
Purpose:
1) In create-example-data, put back the creation of containers (seem to be lost during a refactoring), and place the samples in them. 
2) Fix a bug that hindered the rendition of samples in UI. This bug kicked in when samples were fallbacked from plugin classes to base classes, e.g. instantiated as SubstanceBase instead of DemoSample. 
3) Fix a bug that made samples and container instantiated as base classes in ui (SubstanceBase and ContainerBase). 

Implementation:
All extensible types is loaded in working memory (in ExtensibleService). This loading is now done lazily and fetched from database, so that every new instance of ExtensibleService is garanteed to be properly initialized, which was not the case before this bugfix.

Note:
I have not taken into account which versions of the extensible types that is loaded. I couldn't find the field "latest", so I postphoned this until later.  

This PR is a modified version of an old PR, which I closed: https://github.com/commonlims/commonlims/pull/127
