### PR TITLE
New ports for postgres

### DIFF
--- a/middleware/camunda/setup.sh
+++ b/middleware/camunda/setup.sh
@@ -36,8 +36,8 @@ echo "Camunda modeler v${CAMUNDA_MODELER_VERSION} has been installed"
 # TODO: Implement an upgrade path between camunda versions
 CREATE_SCRIPT=~/.camunda/server/${CAMUNDA_VERSION}/sql/create/postgres_engine_${CAMUNDA_VERSION}.sql
 
-psql -h localhost -p 5432 -d clims -U clims -a -f $CREATE_SCRIPT > /dev/null 2>&1
+psql -h localhost -p ${POSTGRES_PORT} -d clims -U clims -a -f $CREATE_SCRIPT > /dev/null 2>&1
 echo "Camunda SQL v${CAMUNDA_VERSION} has been deployed to clims"
 
-psql -h localhost -p 5433 -d test_clims -U test_clims -a -f $CREATE_SCRIPT > /dev/null 2>&1
+psql -h localhost -p ${POSTGRES_TESTS_PORT} -d test_clims -U test_clims -a -f $CREATE_SCRIPT > /dev/null 2>&1
 echo "Camunda SQL v${CAMUNDA_VERSION} has been deployed to test_clims"

--- a/middleware/local/stack.yml
+++ b/middleware/local/stack.yml
@@ -16,7 +16,7 @@ services:
   db:
     image: postgres:latest
     ports:
-      - 5432:5432
+      - "${POSTGRES_PORT}:5432"
     environment:
       POSTGRES_DB: "${CLIMS_POSTGRES_DB}"
       POSTGRES_USER: "${CLIMS_POSTGRES_USER}"
@@ -26,7 +26,7 @@ services:
   test_db:
     image: postgres:latest
     ports:
-      - 5433:5432
+      - "${POSTGRES_TESTS_PORT}:5432"
     environment:
       POSTGRES_DB: "${TEST_CLIMS_POSTGRES_DB}"
       POSTGRES_USER: "${TEST_CLIMS_POSTGRES_USER}"

--- a/scripts/start-local-middleware.sh
+++ b/scripts/start-local-middleware.sh
@@ -6,6 +6,13 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 export CAMUNDA_VERSION=7.12.0
 
+# Even though we're using docker, we're currently executing some commands via the exposed
+# ports on the host. To make sure we're not using the default postgres instance, we connect
+# to 15432 instead (assuming that's not in use)
+export POSTGRES_PORT=15432
+export POSTGRES_TESTS_PORT=15433
+
+
 # Check if docker is installed and of the expected version
 ${DIR}/version-check.py docker
 
@@ -28,11 +35,12 @@ done
 # Make sure we can reach the different services (smoke test), in particular postgresql so we
 # can run `lims upgrade` directly.
 
-echo "Waiting for postgres (5432) to respond..."
-while ! nc -z localhost 5432 </dev/null; do sleep 1; done
 
-echo "Waiting for postgres (5433) to respond..."
-while ! nc -z localhost 5433 </dev/null; do sleep 1; done
+echo "Waiting for postgres (${POSTGRES_PORT}) to respond..."
+while ! nc -z localhost ${POSTGRES_PORT} </dev/null; do sleep 1; done
+
+echo "Waiting for postgres (${POSTGRES_TESTS_PORT}) to respond..."
+while ! nc -z localhost ${POSTGRES_TESTS_PORT} </dev/null; do sleep 1; done
 
 echo "--> Setting up Camunda"
 $DIR/.././middleware/camunda/setup.sh

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -111,7 +111,7 @@ DATABASES = {
         'USER': 'postgres',
         'PASSWORD': '',
         'HOST': 'localhost',
-        'PORT': '',
+        'PORT': '15432',
         'AUTOCOMMIT': True,
         'ATOMIC_REQUESTS': False,
     }

--- a/src/sentry/data/config/clims.conf.py.default
+++ b/src/sentry/data/config/clims.conf.py.default
@@ -13,7 +13,7 @@ DATABASES = {
         'USER': 'clims',
         'PASSWORD': '',
         'HOST': 'localhost',
-        'PORT': '',
+        'PORT': '15432',
         'AUTOCOMMIT': True,
         'ATOMIC_REQUESTS': False,
     }

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -35,11 +35,10 @@ def pytest_configure(config):
     integrationdocs.DOC_FOLDER = os.environ['INTEGRATION_DOC_FOLDER']
 
     # Configure the test database
-
     settings.DATABASES['default'].update(
         {
             'ENGINE': 'sentry.db.postgres',
-            'PORT': '5433',  # Docker image for the test database is exposed at 5433
+            'PORT': '15433',  # Docker image for the test database is exposed at 5433
             'USER': 'test_clims',
             'NAME': 'clims',  # Django will add the test_ prefix
         }


### PR DESCRIPTION
Using a different port than 5432 since it may clash with an already
installed version.