### PR TITLE
278, expandable list, group samples on containers

### DIFF
--- a/src/sentry/static/sentry/app/components/listView.jsx
+++ b/src/sentry/static/sentry/app/components/listView.jsx
@@ -99,6 +99,14 @@ class ListView extends React.Component {
     }
   }
 
+  getFontStyle(entryId, header) {
+    const row = this.props.dataById[entryId];
+    if (header.fontstyle !== undefined) {
+      return header.fontstyle(row);
+    }
+    return 'normal';
+  }
+
   getDisplayCell(entryId, header) {
     const row = this.props.dataById[entryId];
     if (typeof header.accessor === 'function') {
@@ -161,7 +169,10 @@ class ListView extends React.Component {
                       )}
                       {this.props.columns.map((header, index) => {
                         return (
-                          <td key={'parent-cell-' + entryId + '-' + index}>
+                          <td
+                            key={'parent-cell-' + entryId + '-' + index}
+                            style={{fontStyle: this.getFontStyle(entryId, header)}}
+                          >
                             {this.getDisplayCell(entryId, header)}
                           </td>
                         );

--- a/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import {getRestcall} from 'app/redux/utils/substanceSearch';
 
 // SubstancesSearchEntry encapsulates a potentially grouped entry in the substance search UI
 // The store always has one page worth of data. The list contains a generic wrapper class
@@ -58,33 +59,9 @@ export const substanceSearchEntriesGet = (
 ) => dispatch => {
   dispatch(substanceSearchEntriesGetRequest(search, groupBy, cursor));
 
-  let endpoint = null;
-  let request = null;
-  if (groupBy === 'sample_type') {
-    endpoint = '/api/0/organizations/lab/substances/property/' + groupBy + '/';
-    request = {
-      params: {
-        unique: true,
-      },
-    };
-  } else if (groupBy === 'container') {
-    endpoint = '/api/0/organizations/lab/containers/';
-    request = {
-      params: {
-        unique: true,
-      },
-    };
-  } else {
-    endpoint = '/api/0/organizations/lab/substances/';
-    request = {
-      params: {
-        search,
-        cursor,
-      },
-    };
-  }
+  const restCall = getRestcall(search, groupBy, cursor);
   return axios
-    .get(endpoint, request)
+    .get(restCall.endpoint, restCall.request)
     .then(res => {
       dispatch(
         substanceSearchEntriesGetSuccess(

--- a/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
@@ -33,12 +33,14 @@ export const substanceSearchEntriesGetRequest = (search, groupBy, cursor) => {
 export const substanceSearchEntriesGetSuccess = (
   substanceSearchEntries,
   link,
+  groupBy,
   isGroupHeader
 ) => {
   return {
     type: SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS,
     substanceSearchEntries,
     link,
+    groupBy,
     isGroupHeader,
   };
 };
@@ -56,38 +58,44 @@ export const substanceSearchEntriesGet = (
 ) => dispatch => {
   dispatch(substanceSearchEntriesGetRequest(search, groupBy, cursor));
 
-  if (!isGroupHeader) {
-    const request = {
+  let endpoint = null;
+  let request = null;
+  if (groupBy === 'sample_type') {
+    endpoint = '/api/0/organizations/lab/substances/property/' + groupBy + '/';
+    request = {
+      params: {
+        unique: true,
+      },
+    };
+  } else if (groupBy === 'container') {
+    endpoint = '/api/0/organizations/lab/containers/';
+    request = {
+      params: {
+        unique: true,
+      },
+    };
+  } else {
+    endpoint = '/api/0/organizations/lab/substances/';
+    request = {
       params: {
         search,
         cursor,
       },
     };
-    return axios
-      .get('/api/0/organizations/lab/substances/', request)
-      .then(res => {
-        dispatch(
-          substanceSearchEntriesGetSuccess(res.data, res.headers.link, isGroupHeader)
-        );
-      })
-      .catch(err => dispatch(substanceSearchEntriesGetFailure(err)));
-  } else {
-    // TODO: search and cursor should be implemented as well
-    const request = {
-      params: {
-        unique: true,
-      },
-    };
-    const url = '/api/0/organizations/lab/substances/property/' + groupBy + '/';
-    return axios
-      .get(url, request)
-      .then(res => {
-        dispatch(
-          substanceSearchEntriesGetSuccess(res.data, res.headers.link, isGroupHeader)
-        );
-      })
-      .catch(err => dispatch(substanceSearchEntriesGetFailure(err)));
   }
+  return axios
+    .get(endpoint, request)
+    .then(res => {
+      dispatch(
+        substanceSearchEntriesGetSuccess(
+          res.data,
+          res.headers.link,
+          groupBy,
+          isGroupHeader
+        )
+      );
+    })
+    .catch(err => dispatch(substanceSearchEntriesGetFailure(err)));
 };
 
 export const substanceSearchEntriesToggleSelectAll = doSelect => {

--- a/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
@@ -34,15 +34,13 @@ export const substanceSearchEntriesGetRequest = (search, groupBy, cursor) => {
 export const substanceSearchEntriesGetSuccess = (
   substanceSearchEntries,
   link,
-  groupBy,
-  isGroupHeader
+  groupBy
 ) => {
   return {
     type: SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS,
     substanceSearchEntries,
     link,
     groupBy,
-    isGroupHeader,
   };
 };
 
@@ -51,26 +49,14 @@ export const substanceSearchEntriesGetFailure = err => ({
   message: err,
 });
 
-export const substanceSearchEntriesGet = (
-  search,
-  groupBy,
-  cursor,
-  isGroupHeader
-) => dispatch => {
+export const substanceSearchEntriesGet = (search, groupBy, cursor) => dispatch => {
   dispatch(substanceSearchEntriesGetRequest(search, groupBy, cursor));
 
   const restCall = getRestcall(search, groupBy, cursor);
   return axios
     .get(restCall.endpoint, restCall.request)
     .then(res => {
-      dispatch(
-        substanceSearchEntriesGetSuccess(
-          res.data,
-          res.headers.link,
-          groupBy,
-          isGroupHeader
-        )
-      );
+      dispatch(substanceSearchEntriesGetSuccess(res.data, res.headers.link, groupBy));
     })
     .catch(err => dispatch(substanceSearchEntriesGetFailure(err)));
 };

--- a/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
@@ -50,9 +50,15 @@ const substanceSearchEntry = (state = initialState, action) => {
       const byIds = {};
       let i = 1;
       for (const entry of action.substanceSearchEntries) {
+        const name = null;
+        if (action.groupBy === 'sample_type') {
+          name = entry;
+        } else if (action.groupBy === 'container') {
+          name = entry.name;
+        }
         const groupedEntry = {
           id: i++,
-          name: entry,
+          name,
         };
         const adaptedEntry = action.isGroupHeader ? groupedEntry : {...entry};
         adaptedEntry.isGroupHeader = action.isGroupHeader;

--- a/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
@@ -1,4 +1,5 @@
 import {Set} from 'immutable';
+import {ListViewEntryGenerator} from 'app/redux/utils/substanceSearch';
 
 import {
   SUBSTANCE_SEARCH_ENTRIES_GET_REQUEST,
@@ -48,21 +49,10 @@ const substanceSearchEntry = (state = initialState, action) => {
       // The action provides us with the raw data as a list, here we turn it into
       // a dictionary and then update the store's byIds as required.
       const byIds = {};
-      let i = 1;
+      const entryGenerator = new ListViewEntryGenerator();
       for (const entry of action.substanceSearchEntries) {
-        const name = null;
-        if (action.groupBy === 'sample_type') {
-          name = entry;
-        } else if (action.groupBy === 'container') {
-          name = entry.name;
-        }
-        const groupedEntry = {
-          id: i++,
-          name,
-        };
-        const adaptedEntry = action.isGroupHeader ? groupedEntry : {...entry};
-        adaptedEntry.isGroupHeader = action.isGroupHeader;
-        byIds[adaptedEntry.id] = adaptedEntry;
+        const listViewEntry = entryGenerator.get(action.groupBy, entry);
+        byIds[listViewEntry.id] = listViewEntry;
       }
       const visibleIds = Object.keys(byIds).map(Number);
 

--- a/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
@@ -54,7 +54,7 @@ const substanceSearchEntry = (state = initialState, action) => {
           id: i++,
           name: entry,
         };
-        const adaptedEntry = action.isGroupHeader ? groupedEntry : entry;
+        const adaptedEntry = action.isGroupHeader ? groupedEntry : {...entry};
         adaptedEntry.isGroupHeader = action.isGroupHeader;
         byIds[adaptedEntry.id] = adaptedEntry;
       }

--- a/src/sentry/static/sentry/app/redux/utils/substanceSearch.js
+++ b/src/sentry/static/sentry/app/redux/utils/substanceSearch.js
@@ -1,0 +1,56 @@
+export function getRestcall(search, groupBy, cursor) {
+  let endpoint = null;
+  let request = null;
+  if (groupBy === 'sample_type') {
+    endpoint = '/api/0/organizations/lab/substances/property/' + groupBy + '/';
+    request = {
+      params: {
+        unique: true,
+      },
+    };
+  } else if (groupBy === 'container') {
+    endpoint = '/api/0/organizations/lab/containers/';
+    request = {
+      params: {
+        unique: true,
+      },
+    };
+  } else {
+    endpoint = '/api/0/organizations/lab/substances/';
+    request = {
+      params: {
+        search,
+        cursor,
+      },
+    };
+  }
+  return {
+    endpoint,
+    request,
+  };
+}
+
+// Generate json that is adapted to list view,
+// e.g. assure id is present for group header, and that there always is a 'name' attribute
+export class ListViewEntryGenerator {
+  constructor() {
+    this.tempId = 1;
+  }
+
+  get(groupBy, originalEntry) {
+    const isGroupHeader = groupBy !== 'substance';
+    let name = null;
+    if (groupBy === 'sample_type') {
+      name = originalEntry;
+    } else if (groupBy === 'container') {
+      name = originalEntry.name;
+    }
+    const tempEntry = {
+      id: this.tempId++,
+      name,
+    };
+    const listViewEntry = isGroupHeader ? tempEntry : {...originalEntry};
+    listViewEntry.isGroupHeader = isGroupHeader;
+    return listViewEntry;
+  }
+}

--- a/src/sentry/static/sentry/app/views/substances/substances.jsx
+++ b/src/sentry/static/sentry/app/views/substances/substances.jsx
@@ -78,6 +78,7 @@ class Substances extends React.Component {
         Header: 'Sample name',
         id: 'name',
         accessor: 'name',
+        fontstyle: d => (d.isGroupHeader ? 'italic' : 'normal'),
         aggregate: vals => '',
       },
       {

--- a/src/sentry/static/sentry/app/views/substances/substances.jsx
+++ b/src/sentry/static/sentry/app/views/substances/substances.jsx
@@ -79,7 +79,6 @@ class Substances extends React.Component {
         id: 'name',
         accessor: 'name',
         fontstyle: d => (d.isGroupHeader ? 'italic' : 'normal'),
-        aggregate: vals => '',
       },
       {
         Header: 'Container',
@@ -94,7 +93,6 @@ class Substances extends React.Component {
         id: 'index',
         accessor: d =>
           d.isGroupHeader ? null : d.location ? d.location.index : '<No location>',
-        aggregate: vals => '',
       },
       {
         Header: 'Volume',
@@ -105,7 +103,6 @@ class Substances extends React.Component {
             : d.properties && d.properties.volume
               ? showRounded(d.properties.volume.value)
               : null,
-        aggregate: vals => '',
       },
       {
         Header: 'Sample Type',
@@ -121,7 +118,6 @@ class Substances extends React.Component {
         Header: 'Priority',
         id: 'priority',
         accessor: d => (d.isGroupHeader ? null : d.priority),
-        aggregate: vals => '',
       },
       {
         Header: 'Waiting',

--- a/src/sentry/static/sentry/app/views/substances/substances.jsx
+++ b/src/sentry/static/sentry/app/views/substances/substances.jsx
@@ -40,8 +40,7 @@ class Substances extends React.Component {
   }
 
   onSearch(search, groupBy, cursor) {
-    const isGroupHeader = groupBy !== 'substance';
-    this.props.substanceSearchEntriesGet(search, groupBy, cursor, isGroupHeader);
+    this.props.substanceSearchEntriesGet(search, groupBy, cursor);
 
     // Add search to history
     const location = this.props.location;

--- a/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
@@ -82,6 +82,7 @@ describe('substance redux actions', function() {
         {
           type: SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS,
           substanceSearchEntries,
+          groupBy,
           isGroupHeader,
         },
       ];
@@ -124,6 +125,7 @@ describe('substance redux actions', function() {
         },
         {
           type: SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS,
+          groupBy,
           isGroupHeader,
           substanceSearchEntries,
         },

--- a/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
@@ -71,7 +71,6 @@ describe('substance redux actions', function() {
       const search = 'search';
       const groupBy = 'substance';
       const cursor = undefined;
-      const isGroupHeader = false;
 
       const expectedActions = [
         {
@@ -83,13 +82,12 @@ describe('substance redux actions', function() {
           type: SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS,
           substanceSearchEntries,
           groupBy,
-          isGroupHeader,
         },
       ];
 
       // TODO: return
       return store
-        .dispatch(substanceSearchEntriesGet(search, groupBy, cursor, isGroupHeader))
+        .dispatch(substanceSearchEntriesGet(search, groupBy, cursor))
         .then(() => {
           expect(store.getActions()).toEqual(expectedActions);
           const request = moxios.requests.mostRecent();
@@ -126,7 +124,6 @@ describe('substance redux actions', function() {
         {
           type: SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS,
           groupBy,
-          isGroupHeader,
           substanceSearchEntries,
         },
       ];

--- a/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
@@ -132,7 +132,7 @@ describe('substance reducer', () => {
     });
   });
 
-  it('should handle SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS for grouped', () => {
+  it('should handle SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS for sample type', () => {
     // Arrange
     const mockResponseGrouped = ['my_sample_type'];
 
@@ -140,6 +140,7 @@ describe('substance reducer', () => {
       type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
       substanceSearchEntries: mockResponseGrouped,
       link: 'some-link',
+      groupBy: 'sample_type',
       isGroupHeader: true,
     };
 
@@ -157,6 +158,48 @@ describe('substance reducer', () => {
       {
         id: 1,
         name: 'my_sample_type',
+        isGroupHeader: true,
+      },
+    ];
+
+    const mockedByIds = keyBy(mockedResponseFromReducer, entry => entry.id);
+
+    expect(nextState).toEqual({
+      ...prevState,
+      errorMessage: null,
+      loading: false,
+      visibleIds: [1],
+      byIds: mockedByIds,
+      pageLinks: 'some-link',
+    });
+  });
+
+  it('should handle SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS for containers', () => {
+    // Arrange
+    const mockResponseGrouped = [{name: 'mycontainer'}];
+
+    const action = {
+      type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
+      substanceSearchEntries: mockResponseGrouped,
+      link: 'some-link',
+      groupBy: 'container',
+      isGroupHeader: true,
+    };
+
+    const prevState = {
+      ...initialState,
+      loading: true,
+      errorMessage: 'oops',
+    };
+
+    // Act
+    const nextState = substanceSearchEntry(prevState, action);
+
+    // Assert
+    const mockedResponseFromReducer = [
+      {
+        id: 1,
+        name: 'mycontainer',
         isGroupHeader: true,
       },
     ];

--- a/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
@@ -111,6 +111,7 @@ describe('substance reducer', () => {
     const action = {
       type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
       substanceSearchEntries: mockResponseNoGroup,
+      groupBy: 'substance',
       isGroupHeader: false,
       link: 'some-link',
     };

--- a/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
@@ -39,6 +39,67 @@ describe('substance reducer', () => {
     });
   });
 
+  it('state is not mutated when no grouping', () => {
+    // Arrange
+    const prevState = {
+      ...initialState,
+      loading: true,
+      errorMessage: 'oops',
+    };
+
+    const responseNoGroup = TestStubs.SubstanceSearchEntries(2, 'sample');
+
+    const action = {
+      type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
+      substanceSearchEntries: responseNoGroup,
+      isGroupHeader: false,
+      link: 'some-link',
+    };
+
+    const action_orig = JSON.parse(JSON.stringify(action));
+    const prevState_orig = JSON.parse(JSON.stringify(prevState));
+
+    // Act
+    substanceSearchEntry(prevState, action);
+
+    // Assert
+    // It has to be 'copied' in the same way as before. An empty Immutable.Set()
+    // is converted to []
+    const actionAfter = JSON.parse(JSON.stringify(action));
+    const stateAfter = JSON.parse(JSON.stringify(prevState));
+    expect(actionAfter).toEqual(action_orig);
+    expect(stateAfter).toEqual(prevState_orig);
+  });
+
+  it('state is not mutated when grouping', () => {
+    // Arrange
+    const responseGrouped = ['my_sample_type'];
+
+    const prevState = {
+      ...initialState,
+      loading: true,
+      errorMessage: 'oops',
+    };
+
+    const action = {
+      type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
+      substanceSearchEntries: responseGrouped,
+      isGroupHeader: true,
+      link: 'some-link',
+    };
+    const prevState_orig = JSON.parse(JSON.stringify(prevState));
+    const action_orig = JSON.parse(JSON.stringify(action));
+
+    // Act
+    substanceSearchEntry(prevState, action);
+
+    // Assert
+    const treatedAction = JSON.parse(JSON.stringify(action));
+    const treatedState = JSON.parse(JSON.stringify(prevState));
+    expect(treatedAction).toEqual(action_orig);
+    expect(treatedState).toEqual(prevState_orig);
+  });
+
   it('should handle SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS for not-grouped', () => {
     // Arrange
     const prevState = {
@@ -49,7 +110,7 @@ describe('substance reducer', () => {
 
     const action = {
       type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
-      substanceSearchEntries: JSON.parse(JSON.stringify(mockResponseNoGroup)),
+      substanceSearchEntries: mockResponseNoGroup,
       isGroupHeader: false,
       link: 'some-link',
     };
@@ -77,7 +138,7 @@ describe('substance reducer', () => {
 
     const action = {
       type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
-      substanceSearchEntries: JSON.parse(JSON.stringify(mockResponseGrouped)),
+      substanceSearchEntries: mockResponseGrouped,
       link: 'some-link',
       isGroupHeader: true,
     };

--- a/tests/js/spec/views/__snapshots__/listview.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/listview.spec.jsx.snap
@@ -132,11 +132,29 @@ ListView {
                   <td>
                     <CaretRight />
                   </td>
-                  <td>
+                  <td
+                    style={
+                      Object {
+                        "fontStyle": "normal",
+                      }
+                    }
+                  >
                     Zombie brain
                   </td>
-                  <td />
-                  <td />
+                  <td
+                    style={
+                      Object {
+                        "fontStyle": "normal",
+                      }
+                    }
+                  />
+                  <td
+                    style={
+                      Object {
+                        "fontStyle": "normal",
+                      }
+                    }
+                  />
                 </tr>
               </tbody>
             </table>


### PR DESCRIPTION
Purpose:
Continue with the work on showing an expandable/grouped list at the "Samples" entry point. Here, grouped headers are shown for both "sample type" and "containers" in the "group by" dropdown list. However, the *expand* functionality is not yet implemented, i.e. pressing the downarrow at the margin. 

Refactorings:
Move some logic from the redux action/reducer classes to a utility module. Also, assert that the reducer don't mutate state. 

Shortcommings:
As implemented now, both sample ids and container ids is used in the array byIds in substanceSearchEntry. There will probably be clashes between them in future. I have written a ticket for this. 