### PR TITLE
clims 365, prevent id clashes in groupable list view

### DIFF
--- a/src/clims/api/serializers/models/container.py
+++ b/src/clims/api/serializers/models/container.py
@@ -13,6 +13,7 @@ class ContainerSerializer(serializers.Serializer):
     name = serializers.CharField()
     properties = DictField(child=ExtensiblePropertySerializer(read_only=True))
     type_full_name = serializers.CharField()
+    global_id = serializers.CharField(read_only=True)
 
 
 class ContainerExpandedSerializer(ContainerSerializer):

--- a/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
@@ -52,9 +52,9 @@ const substanceSearchEntry = (state = initialState, action) => {
       const entryGenerator = new ListViewEntryGenerator();
       for (const entry of action.substanceSearchEntries) {
         const listViewEntry = entryGenerator.get(action.groupBy, entry);
-        byIds[listViewEntry.id] = listViewEntry;
+        byIds[listViewEntry.global_id] = listViewEntry;
       }
-      const visibleIds = Object.keys(byIds).map(Number);
+      const visibleIds = Object.keys(byIds).map(String);
 
       return {
         ...state,

--- a/src/sentry/static/sentry/app/redux/utils/substanceSearch.js
+++ b/src/sentry/static/sentry/app/redux/utils/substanceSearch.js
@@ -40,13 +40,16 @@ export class ListViewEntryGenerator {
   get(groupBy, originalEntry) {
     const isGroupHeader = groupBy !== 'substance';
     let name = null;
+    let global_id = null;
     if (groupBy === 'sample_type') {
       name = originalEntry;
+      global_id = 'Parent-' + this.tempId++;
     } else if (groupBy === 'container') {
       name = originalEntry.name;
+      global_id = originalEntry.global_id;
     }
     const tempEntry = {
-      id: this.tempId++,
+      global_id,
       name,
     };
     const listViewEntry = isGroupHeader ? tempEntry : {...originalEntry};

--- a/tests/js/fixtures/substances.js
+++ b/tests/js/fixtures/substances.js
@@ -15,6 +15,7 @@ export function Substance(id, props) {
   // TODO: Use javascript conventions with the names in the data contract (camel case)
   const ret = {
     id,
+    global_id: 'Substance-' + id,
     version: 1,
     name: 'sample-' + id,
     type_full_name: 'clims.services.substance.SubstanceBase',
@@ -35,7 +36,7 @@ export function Substance(id, props) {
 }
 
 export function SubstanceSearchEntry(groupBy, id) {
-  if (groupBy === 'sample') {
+  if (groupBy === 'substance') {
     // This is the same as grouping by nothing, so we get a flat list of substances
     // (with an added view state)
     return Substance(id, ['comment', 'flammability', 'sample_type']);
@@ -63,7 +64,7 @@ function SubstanceEntryFromReducer(groupBy, id, isGroupHeader) {
 
 export function SubstanceEntriesFromReducer(count, groupBy) {
   const ret = [];
-  const isGroupHeader = groupBy !== 'sample';
+  const isGroupHeader = groupBy !== 'substance';
   for (let i = 0; i < count; i++) {
     ret.push(SubstanceEntryFromReducer(groupBy, i + 1, isGroupHeader));
   }
@@ -81,11 +82,11 @@ export function SubstanceSearchEntries(count, groupBy) {
 export function SubstanceSearchEntriesPageState(pageSize, groupBy) {
   // NOTE: This stub uses the state management to build a page in the expected state
   // Returns the entire expected state a full page mocked objects after one fetches one page of data
-  const mockResponseNoGroup = TestStubs.SubstanceSearchEntries(2, groupBy);
-
+  const mockResponseNoGroup = TestStubs.SubstanceSearchEntries(pageSize, groupBy);
   const nextState = substanceSearchEntry(initialState, {
     type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
     substanceSearchEntries: mockResponseNoGroup,
+    groupBy,
   });
   return nextState;
 }

--- a/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
@@ -28,7 +28,7 @@ describe('substance redux actions', function() {
     moxios.uninstall();
   });
 
-  const mockResponseNoGroup = TestStubs.SubstanceSearchEntries(5, 'sample');
+  const mockResponseNoGroup = TestStubs.SubstanceSearchEntries(5, 'substance');
 
   describe('get', () => {
     it('should create an action to request substance search entries GET', () => {

--- a/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
@@ -8,8 +8,8 @@ import {keyBy} from 'lodash';
 // to search for project, container and substances, but with child elements?
 
 describe('substance reducer', () => {
-  const mockResponseNoGroup = TestStubs.SubstanceSearchEntries(2, 'sample');
-  const mockResponseNoGroupById = keyBy(mockResponseNoGroup, entry => entry.id);
+  const mockResponseNoGroup = TestStubs.SubstanceSearchEntries(2, 'substance');
+  const mockResponseNoGroupById = keyBy(mockResponseNoGroup, entry => entry.global_id);
 
   it('should handle initial state', () => {
     expect(substanceSearchEntry(undefined, {})).toEqual(initialState);
@@ -47,12 +47,12 @@ describe('substance reducer', () => {
       errorMessage: 'oops',
     };
 
-    const responseNoGroup = TestStubs.SubstanceSearchEntries(2, 'sample');
+    const responseNoGroup = TestStubs.SubstanceSearchEntries(2, 'substance');
 
     const action = {
       type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
       substanceSearchEntries: responseNoGroup,
-      isGroupHeader: false,
+      groupBy: 'substance',
       link: 'some-link',
     };
 
@@ -84,7 +84,7 @@ describe('substance reducer', () => {
     const action = {
       type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
       substanceSearchEntries: responseGrouped,
-      isGroupHeader: true,
+      groupBy: 'sample_type',
       link: 'some-link',
     };
     const prevState_orig = JSON.parse(JSON.stringify(prevState));
@@ -112,7 +112,6 @@ describe('substance reducer', () => {
       type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
       substanceSearchEntries: mockResponseNoGroup,
       groupBy: 'substance',
-      isGroupHeader: false,
       link: 'some-link',
     };
 
@@ -121,14 +120,14 @@ describe('substance reducer', () => {
 
     // Assert
 
-    const responseFromReducer = TestStubs.SubstanceEntriesFromReducer(2, 'sample');
-    const mockedByIds = keyBy(responseFromReducer, entry => entry.id);
+    const responseFromReducer = TestStubs.SubstanceEntriesFromReducer(2, 'substance');
+    const expectedByIds = keyBy(responseFromReducer, entry => entry.global_id);
     expect(nextState).toEqual({
       ...prevState,
       errorMessage: null,
       loading: false,
-      visibleIds: [1, 2],
-      byIds: mockedByIds,
+      visibleIds: ['Substance-1', 'Substance-2'],
+      byIds: expectedByIds,
       pageLinks: 'some-link',
     });
   });
@@ -142,7 +141,6 @@ describe('substance reducer', () => {
       substanceSearchEntries: mockResponseGrouped,
       link: 'some-link',
       groupBy: 'sample_type',
-      isGroupHeader: true,
     };
 
     const prevState = {
@@ -155,36 +153,35 @@ describe('substance reducer', () => {
     const nextState = substanceSearchEntry(prevState, action);
 
     // Assert
-    const mockedResponseFromReducer = [
+    const expectedEntryFromReducer = [
       {
-        id: 1,
+        global_id: 'Parent-1',
         name: 'my_sample_type',
         isGroupHeader: true,
       },
     ];
 
-    const mockedByIds = keyBy(mockedResponseFromReducer, entry => entry.id);
+    const expectedByIds = keyBy(expectedEntryFromReducer, entry => entry.global_id);
 
     expect(nextState).toEqual({
       ...prevState,
       errorMessage: null,
       loading: false,
-      visibleIds: [1],
-      byIds: mockedByIds,
+      visibleIds: ['Parent-1'],
+      byIds: expectedByIds,
       pageLinks: 'some-link',
     });
   });
 
   it('should handle SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS for containers', () => {
     // Arrange
-    const mockResponseGrouped = [{name: 'mycontainer'}];
+    const mockResponseGrouped = [{name: 'mycontainer', global_id: 'Container-1'}];
 
     const action = {
       type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
       substanceSearchEntries: mockResponseGrouped,
       link: 'some-link',
       groupBy: 'container',
-      isGroupHeader: true,
     };
 
     const prevState = {
@@ -197,22 +194,22 @@ describe('substance reducer', () => {
     const nextState = substanceSearchEntry(prevState, action);
 
     // Assert
-    const mockedResponseFromReducer = [
+    const expectedEntryFromReducer = [
       {
-        id: 1,
+        global_id: 'Container-1',
         name: 'mycontainer',
         isGroupHeader: true,
       },
     ];
 
-    const mockedByIds = keyBy(mockedResponseFromReducer, entry => entry.id);
+    const expectedByIds = keyBy(expectedEntryFromReducer, entry => entry.global_id);
 
     expect(nextState).toEqual({
       ...prevState,
       errorMessage: null,
       loading: false,
-      visibleIds: [1],
-      byIds: mockedByIds,
+      visibleIds: ['Container-1'],
+      byIds: expectedByIds,
       pageLinks: 'some-link',
     });
   });
@@ -273,13 +270,13 @@ describe('substance reducer', () => {
     // This test makes sure that our test stub returns the expected state, so we don't have
     // to in the tests that use it. Note that this duplicates the test for
     // SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS as the stub uses that action under the hood
-    const prevState = TestStubs.SubstanceSearchEntriesPageState(2, 'sample');
-    expect(prevState.visibleIds).toEqual([1, 2]);
+    const prevState = TestStubs.SubstanceSearchEntriesPageState(2, 'substance');
+    expect(prevState.visibleIds).toEqual(['Substance-1', 'Substance-2']);
     expect(prevState.selectedIds).toEqual(new Set());
   });
 
   it('should handle selecting and deselecting all search entries', () => {
-    const state1 = TestStubs.SubstanceSearchEntriesPageState(2, 'sample');
+    const state1 = TestStubs.SubstanceSearchEntriesPageState(2, 'substance');
     expect(state1.selectedIds.isEmpty()).toBe(true);
 
     const state2 = substanceSearchEntry(state1, {
@@ -287,7 +284,7 @@ describe('substance reducer', () => {
       doSelect: true,
     });
     expect(state2.selectedIds.isEmpty()).toBe(false);
-    expect(state2.selectedIds).toEqual(new Set([1, 2]));
+    expect(state2.selectedIds).toEqual(new Set(['Substance-1', 'Substance-2']));
 
     const state3 = substanceSearchEntry(state2, {
       type: 'SUBSTANCE_SEARCH_ENTRIES_TOGGLE_SELECT_ALL',


### PR DESCRIPTION
In the groupable list view, both samples, containers and temporary ids occurs in the same internal arrays within the redux action/reducers. Since these are internal ids, only unique for each table, there may be clashes between ids. Here, the internal ids are replaced to global-ids. 
