### PR TITLE
Add diff logging to redux

### DIFF
--- a/src/sentry/static/sentry/app/components/errors/detailedError.jsx
+++ b/src/sentry/static/sentry/app/components/errors/detailedError.jsx
@@ -5,7 +5,6 @@ import * as Sentry from '@sentry/browser';
 
 import {t} from 'app/locale';
 import InlineSvg from 'app/components/inlineSvg';
-import Button from 'app/components/button';
 
 class DetailedError extends React.Component {
   static propTypes = {
@@ -60,19 +59,6 @@ class DetailedError extends React.Component {
                   </a>
                 )}
               </div>
-
-              {!hideSupportLinks && (
-                <div className="detailed-error-support-links">
-                  {Sentry.lastEventId() && (
-                    <Button priority="link" onClick={this.openFeedback}>
-                      {t('Fill out a report')}
-                    </Button>
-                  )}
-                  <a href="https://status.sentry.io/">{t('Service status')}</a>
-
-                  <a href="https://sentry.io/support/">{t('Contact support')}</a>
-                </div>
-              )}
             </div>
           )}
         </div>

--- a/src/sentry/static/sentry/app/redux/store.js
+++ b/src/sentry/static/sentry/app/redux/store.js
@@ -1,10 +1,15 @@
 /*global process*/
 import {createStore, applyMiddleware} from 'redux';
-import logger from 'redux-logger';
+import {createLogger} from 'redux-logger';
 import thunk from 'redux-thunk';
 import reducer from './reducers/index';
 
 const middleware = [thunk];
+
+const logger = createLogger({
+  diff: true,
+});
+
 if (process.env.NODE_ENV !== 'production') {
   middleware.push(logger);
 }

--- a/tests/js/spec/components/__snapshots__/detailedError.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/detailedError.spec.jsx.snap
@@ -96,20 +96,6 @@ exports[`DetailedError renders 1`] = `
       className="detailed-error-content-footer"
     >
       <div />
-      <div
-        className="detailed-error-support-links"
-      >
-        <a
-          href="https://status.sentry.io/"
-        >
-          Service status
-        </a>
-        <a
-          href="https://sentry.io/support/"
-        >
-          Contact support
-        </a>
-      </div>
     </div>
   </div>
 </div>
@@ -148,20 +134,6 @@ exports[`DetailedError renders with "Retry" button 1`] = `
           onClick={[Function]}
         >
           Retry
-        </a>
-      </div>
-      <div
-        className="detailed-error-support-links"
-      >
-        <a
-          href="https://status.sentry.io/"
-        >
-          Service status
-        </a>
-        <a
-          href="https://sentry.io/support/"
-        >
-          Contact support
         </a>
       </div>
     </div>


### PR DESCRIPTION
Adds diff logging to the redux output, which can be very helpful, but is also very noisy, so it might be nice to be easily able to turn it off. But for now it's always on.

Also removes legacy code.