### PR TITLE
Add the reselect library

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "redux-mock-store": "^1.5.3",
     "redux-thunk": "^2.3.0",
     "reflux": "0.4.1",
+    "reselect": "^4.0.0",
     "scroll-to-element": "^2.0.0",
     "sentry-dreamy-components": "^1.0.0",
     "sprintf-js": "1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11672,6 +11672,11 @@ requires-port@1.0.x, requires-port@^1.0.0, requires-port@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
Introduces the `reselect` library. It's designed to create memoized selectors on top of react data. 

Recommended reading: https://redux.js.org/recipes/computing-derived-data