### PR TITLE
Add helper methods for creating shared reducers and actions

### DIFF
--- a/src/sentry/static/sentry/app/redux/actions/shared.js
+++ b/src/sentry/static/sentry/app/redux/actions/shared.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 // Helper function that creates an action creator.
 // From: https://redux.js.org/recipes/reducing-boilerplate
-export function ac(type, ...argNames) {
+export function makeActionCreator(type, ...argNames) {
   return function(...args) {
     const action = {type};
     argNames.forEach((arg, index) => {
@@ -80,7 +80,7 @@ export const acSelect = resource => {
   };
 };
 
-export const list = {
+export const resourceActionCreators = {
   acRequest,
   acSuccess,
   acFailure,
@@ -93,13 +93,13 @@ export const list = {
 export const makeResourceActions = (resourceName, getListUrl) => {
   return {
     // Fetching a list
-    getListRequest: list.acRequest(resourceName),
-    getListSuccess: list.acSuccess(resourceName),
-    getListFailure: list.acFailure(resourceName),
-    getList: list.acGetList(resourceName, getListUrl),
+    getListRequest: acRequest(resourceName),
+    getListSuccess: acSuccess(resourceName),
+    getListFailure: acFailure(resourceName),
+    getList: acGetList(resourceName, getListUrl),
 
     // Select entries in the list or pages of it
-    select: list.acSelect(resourceName),
-    selectPage: list.acSelectPage(resourceName),
+    select: acSelect(resourceName),
+    selectPage: acSelectPage(resourceName),
   };
 };

--- a/src/sentry/static/sentry/app/redux/actions/shared.js
+++ b/src/sentry/static/sentry/app/redux/actions/shared.js
@@ -1,3 +1,5 @@
+import axios from 'axios';
+
 // Helper function that creates an action creator.
 // From: https://redux.js.org/recipes/reducing-boilerplate
 export function ac(type, ...argNames) {
@@ -9,3 +11,95 @@ export function ac(type, ...argNames) {
     return action;
   };
 }
+
+// Action creators for standard actions
+
+// List actions:
+export const acRequest = resource => {
+  return (search = null, groupBy = null, cursor = null) => {
+    return {
+      type: `GET_${resource}_LIST_REQUEST`,
+      search,
+      groupBy,
+      cursor,
+    };
+  };
+};
+
+export const acSuccess = resource => {
+  return (entries, link) => {
+    return {
+      type: `GET_${resource}_LIST_SUCCESS`,
+      entries,
+      link,
+    };
+  };
+};
+
+export const acFailure = resource => {
+  return err => ({
+    type: `GET_${resource}_LIST_FAILURE`,
+    message: err,
+  });
+};
+
+export const acGetList = (resource, url) => {
+  return (search, groupBy, cursor) => dispatch => {
+    dispatch(acRequest(resource)(search, groupBy, cursor));
+
+    const config = {
+      params: {
+        search,
+        cursor,
+      },
+    };
+
+    return axios
+      .get(url, config)
+      .then(res => dispatch(acSuccess(resource)(res.data, res.headers.link)))
+      .catch(err => dispatch(acFailure(resource)(err)));
+  };
+};
+
+export const acSelectPage = resource => {
+  return doSelect => {
+    return {
+      type: `TOGGLE_SELECT_PAGE_OF_${resource}`,
+      doSelect,
+    };
+  };
+};
+
+export const acSelect = resource => {
+  return (id, doSelect) => {
+    return {
+      type: `TOGGLE_SELECT_${resource}`,
+      id,
+      doSelect,
+    };
+  };
+};
+
+export const list = {
+  acRequest,
+  acSuccess,
+  acFailure,
+  acGetList,
+  acSelect,
+  acSelectPage,
+};
+
+// Creates all actions required for a regular resource
+export const makeResourceActions = (resourceName, getListUrl) => {
+  return {
+    // Fetching a list
+    getListRequest: list.acRequest(resourceName),
+    getListSuccess: list.acSuccess(resourceName),
+    getListFailure: list.acFailure(resourceName),
+    getList: list.acGetList(resourceName, getListUrl),
+
+    // Select entries in the list or pages of it
+    select: list.acSelect(resourceName),
+    selectPage: list.acSelectPage(resourceName),
+  };
+};

--- a/src/sentry/static/sentry/app/redux/actions/shared.js
+++ b/src/sentry/static/sentry/app/redux/actions/shared.js
@@ -1,0 +1,11 @@
+// Helper function that creates an action creator.
+// From: https://redux.js.org/recipes/reducing-boilerplate
+export function ac(type, ...argNames) {
+  return function(...args) {
+    const action = {type};
+    argNames.forEach((arg, index) => {
+      action[argNames[index]] = args[index];
+    });
+    return action;
+  };
+}

--- a/src/sentry/static/sentry/app/redux/reducers/shared.js
+++ b/src/sentry/static/sentry/app/redux/reducers/shared.js
@@ -1,0 +1,219 @@
+import merge from 'lodash/merge';
+import {Set} from 'immutable';
+
+// Defines base state should look for all list components
+//
+
+// Returns an altered listViewState where a single element has been selected or deselected
+// If select is null, the item will be toggled. If it's true, it's selected, if it's false
+// it's deselected
+export function selectSingle(state, action) {
+  const {listViewState} = state;
+  const {id, doSelect} = action;
+
+  const shouldToggle = doSelect === null || doSelect === undefined;
+  const shouldSelect = shouldToggle ? !listViewState.selectedIds.has(id) : doSelect;
+  const newSet = shouldSelect
+    ? listViewState.selectedIds.add(id)
+    : listViewState.selectedIds.delete(id);
+
+  return {
+    ...state,
+    listViewState: {
+      ...listViewState,
+      selectedIds: newSet,
+    },
+  };
+}
+
+// Returns a new listViewState, where the entire page (all visible items) has been selected or
+// deselected. If select is true, the entire page is selected. If it's false the entire page is
+// deselected.
+export function selectAll(state, action) {
+  const {doSelect} = action;
+  const togglePage = doSelect === null || doSelect === undefined;
+  const {listViewState} = state;
+  const shouldSelectAll = togglePage ? !listViewState.allVisibleSelected : doSelect;
+  const selected = shouldSelectAll ? Set(listViewState.visibleIds) : Set();
+  return {
+    ...state,
+    listViewState: {
+      ...listViewState,
+      allVisibleSelected: shouldSelectAll,
+      selectedIds: selected,
+    },
+  };
+}
+
+// Returns a new state when a request for getting a list has been received
+export function getListRequest(state, action) {
+  return {
+    ...state,
+    errorMessage: null,
+    loading: true,
+    listViewState: {
+      ...state.listViewState,
+      search: action.search,
+      groupBy: action.groupBy,
+      pagination: {...state.listViewState.pagination, cursor: action.cursor},
+    },
+  };
+}
+
+export function getListSuccess(state, action) {
+  const byIds = {};
+  for (const entry of action.entries) {
+    // nomerge-just workbatches => data
+    byIds[entry.id] = entry;
+  }
+  const visibleIds = action.entries.map(x => x.id);
+
+  return {
+    ...state,
+    errorMessage: null,
+    loading: false,
+    byIds: merge({}, state.byIds, byIds),
+    listViewState: {
+      ...state.listViewState,
+      visibleIds,
+      pagination: {...state.pagination, pageLinks: action.link},
+    },
+  };
+}
+
+export function getListFailure(state, action) {
+  return {
+    ...state,
+    errorMessage: action.message,
+    loading: false,
+  };
+}
+
+export function createEntryRequest(state, action) {
+  return {
+    ...state,
+    creating: true,
+  };
+}
+
+export function createEntrySuccess(state, action) {
+  return {
+    ...state,
+    creating: false,
+  };
+}
+
+export function createEntryFailure(state, action) {
+  return {
+    ...state,
+    creating: false,
+    errorMessage: action.message,
+  };
+}
+
+export function getEntryRequest(state, action) {
+  return {
+    ...state,
+    loadingDetails: true,
+    detailsId: null,
+  };
+}
+
+export function getEntrySuccess(state, action) {
+  const byIds = {};
+  byIds[action.entry.id] = action.entry;
+  return {
+    ...state,
+    loadingDetails: false,
+    detailsId: action.entry.id,
+    byIds: merge({}, state.byIds, byIds),
+  };
+}
+
+export function getEntryFailure(state, action) {
+  return {
+    ...state,
+    errorMessage: action.message,
+    loadingDetails: false,
+  };
+}
+
+const createResourceReducer = (resource, initialState) => (
+  state = initialState,
+  action
+) => {
+  switch (action.type) {
+    case `GET_${resource}_LIST_REQUEST`:
+      return getListRequest(state, action);
+    case `GET_${resource}_LIST_SUCCESS`:
+      return getListSuccess(state, action);
+    case `GET_${resource}_LIST_FAILURE`:
+      return getListFailure(state, action);
+    case `TOGGLE_SELECT_${resource}`:
+      return selectSingle(state, action);
+    case `TOGGLE_SELECT_PAGE_OF_${resource}`:
+      return selectAll(state, action);
+    case `GET_${resource}_REQUEST`:
+      return getEntryRequest(state, action);
+    case `GET_${resource}_SUCCESS`:
+      return getEntrySuccess(state, action);
+    case `GET_${resource}_FAILURE`:
+      return getEntryFailure(state, action);
+    default:
+      return state;
+  }
+};
+
+export const list = {
+  // State we require for following a list protocol
+  initialState: {
+    loading: false,
+    errorMessage: null,
+    byIds: {},
+    listViewState: {
+      allVisibleSelected: false,
+      groupBy: null,
+      search: null,
+      visibleIds: [], // Sorted list of items visible in the current page
+      selectedIds: new Set(), // The set of items selected, allowed to be outside of the current page
+      pagination: {
+        pageLinks: null, // The links returned by the backend
+        cursor: null,
+      },
+    },
+    creating: false,
+  },
+
+  // All reducers available for that list:
+  selectSingle,
+  selectAll,
+  getListRequest,
+  getListSuccess,
+  getListFailure,
+};
+
+export const entry = {
+  // Required state for following an entry protocol
+  initialState: {
+    loadingDetails: false,
+    detailsId: null,
+  },
+
+  // All reducers
+  createEntryRequest,
+  createEntrySuccess,
+  createEntryFailure,
+  getEntryRequest,
+  getEntrySuccess,
+  getEntryFailure,
+};
+
+// A resource follows both the list and entry protocols
+export const resource = {
+  initialState: {
+    ...entry.initialState,
+    ...list.initialState,
+  },
+
+  createReducer: createResourceReducer,
+};

--- a/src/sentry/static/sentry/app/redux/reducers/shared.js
+++ b/src/sentry/static/sentry/app/redux/reducers/shared.js
@@ -13,7 +13,7 @@ export function selectSingle(state, action) {
 
   const shouldToggle = doSelect === null || doSelect === undefined;
   const shouldSelect = shouldToggle ? !listViewState.selectedIds.has(id) : doSelect;
-  const newSet = shouldSelect
+  const selectedIds = shouldSelect
     ? listViewState.selectedIds.add(id)
     : listViewState.selectedIds.delete(id);
 
@@ -21,7 +21,7 @@ export function selectSingle(state, action) {
     ...state,
     listViewState: {
       ...listViewState,
-      selectedIds: newSet,
+      selectedIds,
     },
   };
 }


### PR DESCRIPTION
A lot of our actions and reducers duplicate code as it stands today.
This introduces methods for generating both of these with factory
functions.