### PR TITLE
333 expand sample type

### DIFF
--- a/src/clims/services/base_extensible_service.py
+++ b/src/clims/services/base_extensible_service.py
@@ -190,6 +190,9 @@ class BaseExtensibleService(object):
 
 
 class BaseQueryBuilder:
+    # TODO: decide internal query separators
+    QUERY_SEPARATOR = "&&"
+
     def __init__(self, query_from_url):
         self.order_by = None
         self.query_from_url = query_from_url
@@ -213,10 +216,11 @@ class BaseQueryBuilder:
         pass
 
     def _parse_query_from_url(self):
+
         query = self.query_from_url.strip() if self.query_from_url else []
         if len(query) == 0:
             return None, None
-        query = query.split(" ")
+        query = query.split(BaseQueryBuilder.QUERY_SEPARATOR)
 
         if len(query) > 1:
             raise NotImplementedError("Complex queries are not yet supported")

--- a/src/sentry/static/sentry/app/components/listView.jsx
+++ b/src/sentry/static/sentry/app/components/listView.jsx
@@ -102,7 +102,7 @@ class ListView extends React.Component {
   getFontStyle(entryId, header) {
     const row = this.props.dataById[entryId];
     if (header.fontstyle !== undefined) {
-      return header.fontstyle(row);
+      return header.fontstyle(row.isGroupHeader);
     }
     return 'normal';
   }
@@ -110,7 +110,7 @@ class ListView extends React.Component {
   getDisplayCell(entryId, header) {
     const row = this.props.dataById[entryId];
     if (typeof header.accessor === 'function') {
-      return header.accessor(row);
+      return header.accessor(row.entity, row.isGroupHeader);
     }
     return row[header.accessor];
   }

--- a/src/sentry/static/sentry/app/components/listView.jsx
+++ b/src/sentry/static/sentry/app/components/listView.jsx
@@ -66,6 +66,7 @@ class ListView extends React.Component {
     selectedIds: PropTypes.instanceOf(Set),
     dataById: PropTypes.object.isRequired,
     listActionBar: PropTypes.object,
+    expandCollapse: PropTypes.func,
   };
 
   constructor() {
@@ -90,9 +91,7 @@ class ListView extends React.Component {
     if (!entryData.isGroupHeader) {
       return '';
     }
-    const currentlyExpandedRows = this.state.expandedRows;
-    const isRowExpanded = currentlyExpandedRows.includes(entryId);
-    if (isRowExpanded) {
+    if (entryData.children.isExpanded) {
       return <CaretDown />;
     } else {
       return <CaretRight />;
@@ -158,7 +157,13 @@ class ListView extends React.Component {
                 {this.props.visibleIds.map((entryId) => {
                   return (
                     <tr key={'parent-' + entryId}>
-                      <td>{this.renderRowExpander(entryId)}</td>
+                      <td
+                        onClick={() =>
+                          this.props.expandCollapse(this.props.dataById[entryId])
+                        }
+                      >
+                        {this.renderRowExpander(entryId)}
+                      </td>
                       {this.props.canSelect && (
                         <td>
                           <Checkbox

--- a/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
@@ -27,6 +27,8 @@ export const SUBSTANCE_SEARCH_ENTRY_EXPAND_SUCCESS =
   'SUBSTANCE_SEARCH_ENTRY_EXPAND_SUCCESS';
 export const SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_FAILURE =
   'SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_FAILURE';
+export const SUBSTANCE_SEARCH_ENTRY_EXPAND_CACHED =
+  'SUBSTANCE_SEARCH_ENTRY_EXPAND_CACHED';
 export const SUBSTANCE_SEARCH_ENTRY_COLLAPSE = 'SUBSTANCE_SEARCH_ENTRY_COLLAPSE';
 
 export const substanceSearchEntryExpandCollapseRequest = (parentEntry) => {
@@ -62,12 +64,19 @@ export const substanceSearchEntryCollapse = (parentEntry) => {
   };
 };
 
+export const substanceSearchEntryExpandCached = (parentEntry) => {
+  return {
+    type: SUBSTANCE_SEARCH_ENTRY_EXPAND_CACHED,
+    parentEntry,
+  };
+};
+
 export const substanceSearchEntryExpandCollapse = (parentEntry) => (dispatch) => {
   dispatch(substanceSearchEntryExpandCollapseRequest(parentEntry));
   if (parentEntry.children.isExpanded) {
     return dispatch(substanceSearchEntryCollapse(parentEntry));
   } else if (parentEntry.children.isFetched) {
-    return dispatch(substanceSearchEntriesExpandCached(parentEntry));
+    return dispatch(substanceSearchEntryExpandCached(parentEntry));
   } else {
     const request = {
       params: {

--- a/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
@@ -31,14 +31,10 @@ export const substanceSearchEntriesGetRequest = (search, groupBy, cursor) => {
   };
 };
 
-export const substanceSearchEntriesGetSuccess = (
-  substanceSearchEntries,
-  link,
-  groupBy
-) => {
+export const substanceSearchEntriesGetSuccess = (fetchedEntities, link, groupBy) => {
   return {
     type: SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS,
-    substanceSearchEntries,
+    fetchedEntities,
     link,
     groupBy,
   };

--- a/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
@@ -21,6 +21,69 @@ export const SUBSTANCE_SEARCH_ENTRIES_TOGGLE_SELECT_ALL =
   'SUBSTANCE_SEARCH_ENTRIES_TOGGLE_SELECT_ALL';
 export const SUBSTANCE_SEARCH_ENTRY_TOGGLE_SELECT =
   'SUBSTANCE_SEARCH_ENTRY_TOGGLE_SELECT';
+export const SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_REQUEST =
+  'SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_REQUEST';
+export const SUBSTANCE_SEARCH_ENTRY_EXPAND_SUCCESS =
+  'SUBSTANCE_SEARCH_ENTRY_EXPAND_SUCCESS';
+export const SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_FAILURE =
+  'SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_FAILURE';
+export const SUBSTANCE_SEARCH_ENTRY_COLLAPSE = 'SUBSTANCE_SEARCH_ENTRY_COLLAPSE';
+
+export const substanceSearchEntryExpandCollapseRequest = (parentEntry) => {
+  return {
+    type: SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_REQUEST,
+    parentEntry,
+  };
+};
+
+export const substanceSearchEntryExpandCollapseFailure = (err) => {
+  return {
+    type: SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_FAILURE,
+    message: err,
+  };
+};
+
+export const substanceSearchEntryExpandSuccess = (fetchedEntities, link, parentEntry) => {
+  // Entity = raw api response
+  // Entry = api response plus metadata such as children.isFetched,
+  // children.cachedIds, isGroupHeader, etc.
+  return {
+    type: SUBSTANCE_SEARCH_ENTRY_EXPAND_SUCCESS,
+    fetchedEntities,
+    link,
+    parentEntry,
+  };
+};
+
+export const substanceSearchEntryCollapse = (parentEntry) => {
+  return {
+    type: SUBSTANCE_SEARCH_ENTRY_COLLAPSE,
+    parentEntry,
+  };
+};
+
+export const substanceSearchEntryExpandCollapse = (parentEntry) => (dispatch) => {
+  dispatch(substanceSearchEntryExpandCollapseRequest(parentEntry));
+  if (parentEntry.children.isExpanded) {
+    return dispatch(substanceSearchEntryCollapse(parentEntry));
+  } else if (parentEntry.children.isFetched) {
+    return dispatch(substanceSearchEntriesExpandCached(parentEntry));
+  } else {
+    const request = {
+      params: {
+        search: 'substance.sample_type:' + parentEntry.entity.name,
+      },
+    };
+    return axios
+      .get('/api/0/organizations/lab/substances/', request)
+      .then((res) => {
+        dispatch(
+          substanceSearchEntryExpandSuccess(res.data, res.headers.link, parentEntry)
+        );
+      })
+      .catch((err) => dispatch(substanceSearchEntryExpandCollapseFailure(err)));
+  }
+};
 
 export const substanceSearchEntriesGetRequest = (search, groupBy, cursor) => {
   return {

--- a/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
@@ -50,9 +50,10 @@ const substanceSearchEntry = (state = initialState, action) => {
       // a dictionary and then update the store's byIds as required.
       const byIds = {};
       const entryGenerator = new ListViewEntryGenerator();
-      for (const entry of action.substanceSearchEntries) {
-        const listViewEntry = entryGenerator.get(action.groupBy, entry);
-        byIds[listViewEntry.global_id] = listViewEntry;
+      const byIds = {};
+      for (const entity of action.fetchedEntities) {
+        const listViewEntry = entryGenerator.get(action.groupBy, entity);
+        byIds[listViewEntry.entity.global_id] = listViewEntry;
       }
       const visibleIds = Object.keys(byIds).map(String);
 

--- a/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/reducers/substanceSearchEntry.js
@@ -72,6 +72,7 @@ const substanceSearchEntry = (state = initialState, action) => {
         errorMessage: null,
         loading: false,
         visibleIds: expandedState.visibleIds,
+        byIds: expandedState.byIds,
         pageLinks: action.link,
       };
     case SUBSTANCE_SEARCH_ENTRY_COLLAPSE:
@@ -81,6 +82,7 @@ const substanceSearchEntry = (state = initialState, action) => {
         errorMessage: null,
         loading: false,
         visibleIds: expandedState.visibleIds,
+        byIds: expandedState.byIds,
         pageLinks: action.link,
       };
     case SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_FAILURE:

--- a/src/sentry/static/sentry/app/redux/utils/expandedState.js
+++ b/src/sentry/static/sentry/app/redux/utils/expandedState.js
@@ -25,6 +25,7 @@ export class ExpandedState {
     const ind = this.visibleIds.findIndex((e) => e == parentId);
     const numberChildren = this.byIds[parentId].children.cachedIds.length;
     this.visibleIds.splice(ind + 1, numberChildren);
+    this.setToCollapsed(parentId);
   }
   cacheChildren(parentEntry, cachedIds) {
     return {
@@ -32,6 +33,7 @@ export class ExpandedState {
       children: {
         ...parentEntry.children,
         isFetched: true,
+        isExpanded: true,
         cachedIds,
       },
     };
@@ -40,5 +42,25 @@ export class ExpandedState {
   expandCached(parentId, expandedIds) {
     const ind = this.visibleIds.findIndex((e) => e == parentId);
     this.visibleIds.splice(ind + 1, 0, ...expandedIds);
+    this.setToExpanded(parentId);
+  }
+
+  setToExpanded(entryId) {
+    this.setExpandedState(entryId, true);
+  }
+
+  setToCollapsed(entryId) {
+    this.setExpandedState(entryId, false);
+  }
+
+  setExpandedState(entryId, expandedState) {
+    const parentEntry = this.byIds[entryId];
+    this.byIds[entryId] = {
+      ...parentEntry,
+      children: {
+        ...parentEntry.children,
+        isExpanded: expandedState,
+      },
+    };
   }
 }

--- a/src/sentry/static/sentry/app/redux/utils/expandedState.js
+++ b/src/sentry/static/sentry/app/redux/utils/expandedState.js
@@ -1,0 +1,44 @@
+import merge from 'lodash/merge';
+
+// Holds state of byIds and visibleIds. Provides methods when these two
+// are updated simultaneously
+export class ExpandedState {
+  constructor(byIds, visibleIds) {
+    this.byIds = byIds;
+    this.visibleIds = visibleIds;
+  }
+
+  expandEntry(parentId, expandedByIds) {
+    const ind = this.visibleIds.findIndex((e) => e == parentId);
+    const expandedIds = Object.keys(expandedByIds);
+    this.visibleIds.splice(ind + 1, 0, ...expandedIds);
+    this.byIds = merge({}, this.byIds, expandedByIds);
+    this.byIds[parentId] = this.cacheChildren(this.byIds[parentId], expandedIds);
+  }
+
+  collapseEntry(parentId) {
+    if (!this.byIds[parentId].children.isFetched) {
+      throw Error(
+        'The parent to be collapsed are supposed to have fetched its children!'
+      );
+    }
+    const ind = this.visibleIds.findIndex((e) => e == parentId);
+    const numberChildren = this.byIds[parentId].children.cachedIds.length;
+    this.visibleIds.splice(ind + 1, numberChildren);
+  }
+  cacheChildren(parentEntry, cachedIds) {
+    return {
+      ...parentEntry,
+      children: {
+        ...parentEntry.children,
+        isFetched: true,
+        cachedIds,
+      },
+    };
+  }
+
+  expandCached(parentId, expandedIds) {
+    const ind = this.visibleIds.findIndex((e) => e == parentId);
+    this.visibleIds.splice(ind + 1, 0, ...expandedIds);
+  }
+}

--- a/src/sentry/static/sentry/app/redux/utils/substanceSearch.js
+++ b/src/sentry/static/sentry/app/redux/utils/substanceSearch.js
@@ -37,22 +37,20 @@ export class ListViewEntryGenerator {
     this.tempId = 1;
   }
 
-  get(groupBy, originalEntry) {
+  get(groupBy, entity) {
     const isGroupHeader = groupBy !== 'substance';
-    let name = null;
-    let global_id = null;
+
+    let tempEntity = null;
     if (groupBy === 'sample_type') {
-      name = originalEntry;
-      global_id = 'Parent-' + this.tempId++;
-    } else if (groupBy === 'container') {
-      name = originalEntry.name;
-      global_id = originalEntry.global_id;
+      tempEntity = {
+        global_id: 'Parent-' + this.tempId++,
+        name: entity,
+      };
     }
-    const tempEntry = {
-      global_id,
-      name,
+    const needTempEntry = groupBy === 'sample_type';
+    const listViewEntry = {
+      entity: needTempEntry ? tempEntity : {...entity},
     };
-    const listViewEntry = isGroupHeader ? tempEntry : {...originalEntry};
     listViewEntry.isGroupHeader = isGroupHeader;
     return listViewEntry;
   }

--- a/src/sentry/static/sentry/app/redux/utils/substanceSearch.js
+++ b/src/sentry/static/sentry/app/redux/utils/substanceSearch.js
@@ -37,7 +37,7 @@ export class ListViewEntryGenerator {
     this.tempId = 1;
   }
 
-  get(groupBy, entity) {
+  wrap(entity, groupBy = 'substance') {
     const isGroupHeader = groupBy !== 'substance';
 
     let tempEntity = null;
@@ -52,6 +52,7 @@ export class ListViewEntryGenerator {
       entity: needTempEntry ? tempEntity : {...entity},
     };
     listViewEntry.isGroupHeader = isGroupHeader;
+
     return listViewEntry;
   }
 }

--- a/src/sentry/static/sentry/app/redux/utils/substanceSearch.js
+++ b/src/sentry/static/sentry/app/redux/utils/substanceSearch.js
@@ -53,6 +53,15 @@ export class ListViewEntryGenerator {
     };
     listViewEntry.isGroupHeader = isGroupHeader;
 
+    if (isGroupHeader){
+      listViewEntry.children = {
+        isFetched: false,
+        isExpanded: false,
+        cachedIds: [],
+      };
+    };
+
     return listViewEntry;
+
   }
 }

--- a/src/sentry/static/sentry/app/redux/utils/substanceSearch.js
+++ b/src/sentry/static/sentry/app/redux/utils/substanceSearch.js
@@ -53,15 +53,14 @@ export class ListViewEntryGenerator {
     };
     listViewEntry.isGroupHeader = isGroupHeader;
 
-    if (isGroupHeader){
+    if (isGroupHeader) {
       listViewEntry.children = {
         isFetched: false,
         isExpanded: false,
         cachedIds: [],
       };
-    };
+    }
 
     return listViewEntry;
-
   }
 }

--- a/src/sentry/static/sentry/app/views/substances/substances.jsx
+++ b/src/sentry/static/sentry/app/views/substances/substances.jsx
@@ -76,30 +76,26 @@ class Substances extends React.Component {
       {
         Header: 'Sample name',
         id: 'name',
-        accessor: 'name',
-        fontstyle: (d) => (d.isGroupHeader ? 'italic' : 'normal'),
+        accessor: (d) => d.name,
+        fontstyle: (isGroupHeader) => (isGroupHeader ? 'italic' : 'normal'),
       },
       {
         Header: 'Container',
         id: 'container',
-        accessor: (d) =>
-          d.isGroupHeader
-            ? null
-            : d.location
-            ? d.location.container.name
-            : '<No location>',
+        accessor: (d, isGroupHeader) =>
+          isGroupHeader ? null : d.location ? d.location.container.name : '<No location>',
       },
       {
         Header: 'Index',
         id: 'index',
-        accessor: (d) =>
-          d.isGroupHeader ? null : d.location ? d.location.index : '<No location>',
+        accessor: (d, isGroupHeader) =>
+          isGroupHeader ? null : d.location ? d.location.index : '<No location>',
       },
       {
         Header: 'Volume',
         id: 'volume',
-        accessor: (d) =>
-          d.isGroupHeader
+        accessor: (d, isGroupHeader) =>
+          isGroupHeader
             ? null
             : d.properties && d.properties.volume
             ? showRounded(d.properties.volume.value)
@@ -108,8 +104,8 @@ class Substances extends React.Component {
       {
         Header: 'Sample Type',
         id: 'sample_type',
-        accessor: (d) =>
-          d.isGroupHeader
+        accessor: (d, isGroupHeader) =>
+          isGroupHeader
             ? null
             : d.properties && d.properties.sample_type
             ? d.properties.sample_type.value
@@ -118,12 +114,12 @@ class Substances extends React.Component {
       {
         Header: 'Priority',
         id: 'priority',
-        accessor: (d) => (d.isGroupHeader ? null : d.priority),
+        accessor: (d, isGroupHeader) => (isGroupHeader ? null : d.priority),
       },
       {
         Header: 'Waiting',
         id: 'days_waiting',
-        accessor: (d) => (d.isGroupHeader ? null : d.days_waiting),
+        accessor: (d, isGroupHeader) => (isGroupHeader ? null : d.days_waiting),
       },
     ];
   }

--- a/src/sentry/static/sentry/app/views/substances/substances.jsx
+++ b/src/sentry/static/sentry/app/views/substances/substances.jsx
@@ -7,6 +7,7 @@ import {
   substanceSearchEntriesGet,
   substanceSearchEntriesToggleSelectAll,
   substanceSearchEntryToggleSelect,
+  substanceSearchEntryExpandCollapse,
 } from 'app/redux/actions/substanceSearchEntry';
 import {t} from 'app/locale';
 import ListFilters from 'app/components/listFilters';
@@ -193,6 +194,7 @@ class Substances extends React.Component {
             toggleAll={this.toggleAll}
             toggleSingle={this.props.substanceSearchEntryToggleSelect}
             listActionBar={actionBar}
+            expandCollapse={this.props.substanceSearchEntryExpandCollapse}
           />
 
           {this.props.substanceSearchEntry.paginationEnabled &&
@@ -215,6 +217,7 @@ Substances.propTypes = {
   groupBy: PropTypes.string.isRequired,
   substanceSearchEntriesGet: PropTypes.func.isRequired,
   substanceSearchEntriesToggleSelectAll: PropTypes.func.isRequired,
+  substanceSearchEntryExpandCollapse: PropTypes.func.isRequired,
   byIds: PropTypes.object,
   substanceSearchEntryToggleSelect: PropTypes.func.isRequired,
   substanceSearchEntry: PropTypes.object,
@@ -236,6 +239,8 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(substanceSearchEntriesToggleSelectAll(doSelect)),
   substanceSearchEntryToggleSelect: (id, doSelect) =>
     dispatch(substanceSearchEntryToggleSelect(id, doSelect)),
+  substanceSearchEntryExpandCollapse: (parentEntry) =>
+    dispatch(substanceSearchEntryExpandCollapse(parentEntry)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Substances);

--- a/tests/clims/api/endpoints/test_substances.py
+++ b/tests/clims/api/endpoints/test_substances.py
@@ -100,6 +100,34 @@ class SubstancesTest(APITestCase):
 
         asserts(stone1, data_by_id[stone1.id])
 
+    @pytest.mark.dev_edvard
+    def test_filter_substances_on_property__with_spaces(self):
+        stone1 = self.create_gemstone(color='red red')
+        self.create_gemstone(color='blue')
+
+        url = reverse('clims-api-0-substances', args=(self.organization.name,))
+        self.login_as(self.user)
+        response = self.client.get(url + '?search=substance.color:red red')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        data_by_id = {int(entry['id']): entry for entry in response.data}
+
+        def asserts(sample, response):
+            properties = response.pop('properties')
+            assert properties['color']['value'] == sample.properties['color'].value
+            assert response == dict(
+                name=sample.name,
+                version=sample.version,
+                id=sample.id,
+                type_full_name=sample.type_full_name,
+                location=None,
+                global_id="Substance-{}".format(sample.id),
+                container_index=None,
+            )
+
+        asserts(stone1, data_by_id[stone1.id])
+
     def test_post_substance(self):
         # Setup
         extensible_type = self.register_extensible(GemstoneSample)

--- a/tests/clims/api/endpoints/test_substances.py
+++ b/tests/clims/api/endpoints/test_substances.py
@@ -123,7 +123,6 @@ class SubstancesTest(APITestCase):
                 type_full_name=sample.type_full_name,
                 location=None,
                 global_id="Substance-{}".format(sample.id),
-                container_index=None,
             )
 
         asserts(stone1, data_by_id[stone1.id])

--- a/tests/js/fixtures/substances.js
+++ b/tests/js/fixtures/substances.js
@@ -44,29 +44,33 @@ export function SubstanceSearchEntry(groupBy, id) {
   throw Error('Unknown groupBy: ' + groupBy);
 }
 
-function GroupedEntryFromReducer(groupBy, id) {
+function TempEntry(groupBy, id) {
   return {
     id,
     name: groupBy + id,
   };
 }
 
-function SubstanceEntryFromReducer(groupBy, id, isGroupHeader) {
+function ListViewEntryFromReducer(groupBy, id, isGroupHeader) {
   let entry = null;
+  let entity = null;
   if (!isGroupHeader) {
-    entry = SubstanceSearchEntry(groupBy, id);
+    entity = SubstanceSearchEntry(groupBy, id);
   } else {
-    entry = GroupedEntryFromReducer(groupBy, id);
+    entity = TempEntry(groupBy, id);
   }
-  entry.isGroupHeader = isGroupHeader;
+  entry = {
+    isGroupHeader,
+    entity,
+  };
   return entry;
 }
 
-export function SubstanceEntriesFromReducer(count, groupBy) {
+export function ListViewEntriesFromReducer(count, groupBy) {
   const ret = [];
   const isGroupHeader = groupBy !== 'substance';
   for (let i = 0; i < count; i++) {
-    ret.push(SubstanceEntryFromReducer(groupBy, i + 1, isGroupHeader));
+    ret.push(ListViewEntryFromReducer(groupBy, i + 1, isGroupHeader));
   }
   return ret;
 }
@@ -85,7 +89,7 @@ export function SubstanceSearchEntriesPageState(pageSize, groupBy) {
   const mockResponseNoGroup = TestStubs.SubstanceSearchEntries(pageSize, groupBy);
   const nextState = substanceSearchEntry(initialState, {
     type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
-    substanceSearchEntries: mockResponseNoGroup,
+    fetchedEntities: mockResponseNoGroup,
     groupBy,
   });
   return nextState;

--- a/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
@@ -8,12 +8,19 @@ import {
   SUBSTANCE_SEARCH_ENTRIES_GET_FAILURE,
   SUBSTANCE_SEARCH_ENTRIES_TOGGLE_SELECT_ALL,
   SUBSTANCE_SEARCH_ENTRY_TOGGLE_SELECT,
+  SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_REQUEST,
+  SUBSTANCE_SEARCH_ENTRY_EXPAND_SUCCESS,
+  SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_FAILURE,
+  SUBSTANCE_SEARCH_ENTRY_COLLAPSE,
   substanceSearchEntriesGetRequest,
   substanceSearchEntriesGetSuccess,
   substanceSearchEntriesGetFailure,
   substanceSearchEntriesGet,
   substanceSearchEntryToggleSelect,
   substanceSearchEntriesToggleSelectAll,
+  substanceSearchEntryExpandCollapse,
+  substanceSearchEntryCollapse,
+  substanceSearchEntryExpandCollapseFailure,
 } from 'app/redux/actions/substanceSearchEntry';
 
 const middlewares = [thunk];
@@ -45,6 +52,24 @@ describe('substance redux actions', function () {
         fetchedEntities,
       };
       expect(substanceSearchEntriesGetSuccess(fetchedEntities)).toEqual(expectedAction);
+    });
+
+    it('should create an action to handle entry collapse', () => {
+      const parentEntry = {
+        entity: {
+          name: 'fang',
+          global_id: 'Parent-1',
+        },
+        children: {
+          isFetched: true,
+          isExpanded: true,
+        },
+      };
+      const expectedAction = {
+        type: SUBSTANCE_SEARCH_ENTRY_COLLAPSE,
+        parentEntry,
+      };
+      expect(substanceSearchEntryCollapse(parentEntry)).toEqual(expectedAction);
     });
 
     it('should create an action to handle substance search entries GET failure', () => {
@@ -91,6 +116,89 @@ describe('substance redux actions', function () {
           const request = moxios.requests.mostRecent();
           expect(request.url).toBe('/api/0/organizations/lab/substances/?search=search');
         });
+    });
+
+    it('should create an action to GET substance entries at un-cached expand', async () => {
+      const fetchedEntities = mockResponseNoGroup;
+      const store = mockStore({substances: []});
+
+      moxios.stubRequest(
+        '/api/0/organizations/lab/substances/?search=substance.sample_type:fang',
+        {
+          status: 200,
+          responseText: fetchedEntities,
+          headers: [],
+        }
+      );
+
+      const parentEntry = {
+        entity: {
+          name: 'fang',
+          global_id: 'Parent-1',
+        },
+        children: {
+          isFetched: false,
+        },
+      };
+
+      const expectedActions = [
+        {
+          type: SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_REQUEST,
+          parentEntry,
+        },
+        {
+          type: SUBSTANCE_SEARCH_ENTRY_EXPAND_SUCCESS,
+          fetchedEntities,
+          parentEntry,
+        },
+      ];
+
+      // TODO: return
+      return store.dispatch(substanceSearchEntryExpandCollapse(parentEntry)).then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+        const request = moxios.requests.mostRecent();
+        expect(request.url).toBe(
+          '/api/0/organizations/lab/substances/?search=substance.sample_type:fang'
+        );
+      });
+    });
+
+    it('should create an action to collapse children from parent entry', async () => {
+      const parentEntry = {
+        entity: {
+          name: 'fang',
+          global_id: 'Parent-1',
+        },
+        children: {
+          isFetched: true,
+          isExpanded: true,
+          cachedIds: ['Substance-1'],
+        },
+      };
+
+      const expectedActions = [
+        {
+          type: SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_REQUEST,
+          parentEntry,
+        },
+        {
+          type: SUBSTANCE_SEARCH_ENTRY_COLLAPSE,
+          parentEntry,
+        },
+      ];
+      const store = mockStore();
+      store.dispatch(substanceSearchEntryExpandCollapse(parentEntry));
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+
+    it('should create an action to handle expand failure', () => {
+      const expectedAction = {
+        type: SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_FAILURE,
+        message: 'expand error',
+      };
+      expect(substanceSearchEntryExpandCollapseFailure('expand error')).toEqual(
+        expectedAction
+      );
     });
 
     it('should create an action to GET grouped substances', () => {

--- a/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
@@ -39,14 +39,12 @@ describe('substance redux actions', function () {
     });
 
     it('should create an action to handle substance search entries GET success', () => {
-      const substanceSearchEntries = [mockResponseNoGroup];
+      const fetchedEntities = [mockResponseNoGroup];
       const expectedAction = {
         type: SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS,
-        substanceSearchEntries,
+        fetchedEntities,
       };
-      expect(substanceSearchEntriesGetSuccess(substanceSearchEntries)).toEqual(
-        expectedAction
-      );
+      expect(substanceSearchEntriesGetSuccess(fetchedEntities)).toEqual(expectedAction);
     });
 
     it('should create an action to handle substance search entries GET failure', () => {
@@ -58,13 +56,13 @@ describe('substance redux actions', function () {
     });
 
     it('should create an action to GET substance search entries from the substances API', async () => {
-      const substanceSearchEntries = mockResponseNoGroup;
+      const fetchedEntities = mockResponseNoGroup;
       const store = mockStore({substances: []});
 
       // TODO: New endpoint
       moxios.stubRequest('/api/0/organizations/lab/substances/?search=search', {
         status: 200,
-        responseText: substanceSearchEntries,
+        responseText: fetchedEntities,
         headers: [],
       });
 
@@ -80,7 +78,7 @@ describe('substance redux actions', function () {
         },
         {
           type: SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS,
-          substanceSearchEntries,
+          fetchedEntities,
           groupBy,
         },
       ];
@@ -98,14 +96,14 @@ describe('substance redux actions', function () {
     it('should create an action to GET grouped substances', () => {
       const mockResponseGrouped = ['sample_type1'];
 
-      const substanceSearchEntries = mockResponseGrouped;
+      const fetchedEntities = mockResponseGrouped;
       const store = mockStore({substances: []});
 
       moxios.stubRequest(
         '/api/0/organizations/lab/substances/property/sample_type/?unique=true',
         {
           status: 200,
-          responseText: substanceSearchEntries,
+          responseText: fetchedEntities,
           headers: [],
         }
       );
@@ -124,7 +122,7 @@ describe('substance redux actions', function () {
         {
           type: SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS,
           groupBy,
-          substanceSearchEntries,
+          fetchedEntities,
         },
       ];
       return store

--- a/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
@@ -11,6 +11,7 @@ import {
   SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_REQUEST,
   SUBSTANCE_SEARCH_ENTRY_EXPAND_SUCCESS,
   SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_FAILURE,
+  SUBSTANCE_SEARCH_ENTRY_EXPAND_CACHED,
   SUBSTANCE_SEARCH_ENTRY_COLLAPSE,
   substanceSearchEntriesGetRequest,
   substanceSearchEntriesGetSuccess,
@@ -199,6 +200,45 @@ describe('substance redux actions', function () {
       expect(substanceSearchEntryExpandCollapseFailure('expand error')).toEqual(
         expectedAction
       );
+    });
+
+    it('should create an action to use cached substance entries at cached expand', async () => {
+      const expandedEntries = mockResponseNoGroup;
+      const store = mockStore({substances: []});
+
+      moxios.stubRequest(
+        '/api/0/organizations/lab/substances/?search=substance.sample_type:fang',
+        {
+          status: 200,
+          responseText: expandedEntries,
+          headers: [],
+        }
+      );
+
+      const parentEntry = {
+        entity: {
+          global_id: 'Parent-1',
+          name: 'fang',
+        },
+        children: {
+          isFetched: true,
+          ids: [],
+        },
+      };
+
+      const expectedActions = [
+        {
+          type: SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_REQUEST,
+          parentEntry,
+        },
+        {
+          type: SUBSTANCE_SEARCH_ENTRY_EXPAND_CACHED,
+          parentEntry,
+        },
+      ];
+
+      store.dispatch(substanceSearchEntryExpandCollapse(parentEntry));
+      expect(store.getActions()).toEqual(expectedActions);
     });
 
     it('should create an action to GET grouped substances', () => {

--- a/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
@@ -224,6 +224,24 @@ describe('substance reducer', () => {
     });
   });
 
+  it('should handle SUBSTANCE_SEARCH_ENTRIES_EXPAND_COLLAPSE_FAILURE', () => {
+    const prevState = {
+      ...initialState,
+      loading: true,
+    };
+
+    const nextState = substanceSearchEntry(prevState, {
+      type: 'SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_FAILURE',
+      message: 'oopsiedoodle',
+    });
+
+    expect(nextState).toEqual({
+      ...initialState,
+      loading: false,
+      errorMessage: 'oopsiedoodle',
+    });
+  });
+
   it('should handle SUBSTANCE_SEARCH_ENTRIES_GET_FAILURE', () => {
     const prevState = {
       ...initialState,

--- a/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
@@ -216,7 +216,7 @@ describe('substance reducer', () => {
           isFetched: false,
           isExpanded: false,
           cachedIds: [],
-        }
+        },
       },
     ];
 

--- a/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
@@ -1,6 +1,7 @@
 import substanceSearchEntry, {
   initialState,
 } from 'app/redux/reducers/substanceSearchEntry';
+import merge from 'lodash/merge';
 import {Set} from 'immutable';
 import {keyBy} from 'lodash';
 
@@ -239,6 +240,243 @@ describe('substance reducer', () => {
       ...initialState,
       loading: false,
       errorMessage: 'oopsiedoodle',
+    });
+  });
+
+  it('should handle SUBSTANCE_SEARCH_ENTRIES_EXPAND_SUCCESS', () => {
+    // Arrange
+    const parentEntry = {
+      entity: {
+        global_id: 'Container-2',
+        name: 'mycontainer',
+      },
+      children: {
+        isFetched: false,
+      },
+    };
+
+    const action = {
+      type: 'SUBSTANCE_SEARCH_ENTRY_EXPAND_SUCCESS',
+      fetchedEntities: mockResponseNoGroup,
+      link: 'some-link',
+      parentEntry,
+    };
+
+    const prevState = {
+      ...initialState,
+      visibleIds: ['Container-1', 'Container-2'],
+      byIds: {
+        'Container-2': parentEntry,
+      },
+      loading: true,
+      errorMessage: 'oops',
+    };
+
+    // Act
+    const nextState = substanceSearchEntry(prevState, action);
+
+    // Assert
+    const transformedEntries = mockResponseNoGroup.map((e) => {
+      return {
+        entity: e,
+        isGroupHeader: false,
+      };
+    });
+    const updatedParentEntry = {
+      ...parentEntry,
+      children: {
+        ...parentEntry.children,
+        isFetched: true,
+        cachedIds: mockResponseNoGroup.map((e) => {
+          return e.global_id;
+        }),
+      },
+    };
+    transformedEntries.push(updatedParentEntry);
+
+    const expectedByIds = keyBy(transformedEntries, (entry) => entry.entity.global_id);
+
+    expect(nextState).toEqual({
+      ...prevState,
+      errorMessage: null,
+      loading: false,
+      visibleIds: ['Container-1', 'Container-2', 'Substance-1', 'Substance-2'],
+      byIds: expectedByIds,
+      pageLinks: 'some-link',
+    });
+  });
+
+  it('should handle SUBSTANCE_SEARCH_ENTRIES_EXPAND_CACHED', () => {
+    // Arrange
+    const parentEntry = {
+      entity: {
+        global_id: 'Container-2',
+        name: 'mycontainer',
+      },
+      children: {
+        isFetched: true,
+        cachedIds: mockResponseNoGroup.map((e) => {
+          return e.global_id;
+        }),
+      },
+    };
+
+    const listViewEntries = mockResponseNoGroup.map((e) => {
+      return {
+        entity: e,
+        isGroupHeader: false,
+      };
+    });
+    listViewEntries.push(parentEntry);
+    const originalByIds = keyBy(listViewEntries, (e) => e.entity.global_id);
+
+    const prevState = {
+      ...initialState,
+      visibleIds: ['Container-1', 'Container-2'],
+      byIds: originalByIds,
+      loading: true,
+      errorMessage: 'oops',
+    };
+
+    const action = {
+      type: 'SUBSTANCE_SEARCH_ENTRY_EXPAND_CACHED',
+      parentEntry,
+    };
+
+    // Act
+    const nextState = substanceSearchEntry(prevState, action);
+
+    // Assert
+
+    expect(nextState).toEqual({
+      ...prevState,
+      errorMessage: null,
+      loading: false,
+      visibleIds: ['Container-1', 'Container-2', 'Substance-1', 'Substance-2'],
+      byIds: originalByIds,
+      pageLinks: undefined,
+    });
+  });
+
+  it('should handle SUBSTANCE_SEARCH_ENTRIES_COLLAPSE', () => {
+    // Arrange
+    const parentEntry = {
+      entity: {
+        global_id: 'Container-2',
+        name: 'mycontainer',
+      },
+      children: {
+        isFetched: true,
+        isExpanded: true,
+        cachedIds: mockResponseNoGroup.map((e) => {
+          return e.global_id;
+        }),
+      },
+    };
+
+    const listViewEntries = mockResponseNoGroup.map((e) => {
+      return {
+        entity: e,
+        isGroupHeader: false,
+      };
+    });
+    listViewEntries.push(parentEntry);
+    const byIds = keyBy(listViewEntries, (e) => e.entity.global_id);
+
+    const prevState = {
+      ...initialState,
+      visibleIds: ['Container-1', 'Container-2', 'Substance-1', 'Substance-2'],
+      byIds,
+      loading: true,
+      errorMessage: 'oops',
+    };
+
+    const action = {
+      type: 'SUBSTANCE_SEARCH_ENTRY_COLLAPSE',
+      parentEntry,
+    };
+
+    // Act
+    const nextState = substanceSearchEntry(prevState, action);
+
+    // Assert
+
+    expect(nextState).toEqual({
+      ...prevState,
+      errorMessage: null,
+      loading: false,
+      visibleIds: ['Container-1', 'Container-2'],
+      byIds: byIds,
+      pageLinks: undefined,
+    });
+  });
+
+  it.skip('should use cache at second expand event', () => {
+    // Arrange
+    const parentEntry = {
+      entity: {
+        global_id: 'Container-2',
+        name: 'mycontainer',
+      },
+      children: {
+        isFetched: false,
+      },
+    };
+    const firstAction = {
+      type: 'SUBSTANCE_SEARCH_ENTRY_EXPAND_SUCCESS',
+      expandedEntries: mockResponseNoGroup,
+      link: 'some-link',
+      parentEntry,
+    };
+    const originalState = {
+      ...initialState,
+      visibleIds: ['Container-1', 'Container-2'],
+      byIds: {
+        'Container-2': parentEntry,
+      },
+      loading: true,
+      errorMessage: 'oops',
+    };
+
+    const fetchedState = substanceSearchEntry(originalState, firstAction);
+
+    const cachedParent = fetchedState.byIds[parentEntry.entity.global_id];
+    const cachedAction = {
+      type: 'SUBSTANCE_SEARCH_ENTRY_EXPAND_CACHED',
+      parentEntry: cachedParent,
+    };
+    // Act
+    const expandedState = substanceSearchEntry(fetchedState, cachedAction);
+
+    // Assert
+    const transformedEntries = mockResponseNoGroup.map((e) => {
+      return {
+        entity: e,
+        isGroupHeader: false,
+      };
+    });
+    const updatedParentEntry = {
+      ...parentEntry,
+      children: {
+        ...parentEntry.children,
+        isFetched: true,
+        cachedIds: mockResponseNoGroup.map((e) => {
+          return e.global_id;
+        }),
+      },
+    };
+    transformedEntries.push(updatedParentEntry);
+
+    const expectedByIds = keyBy(transformedEntries, (entry) => entry.entity.global_id);
+
+    console.log(expandedState.visibleIds);
+    expect(expandedState).toEqual({
+      ...originalState,
+      errorMessage: null,
+      loading: false,
+      visibleIds: ['Container-1', 'Container-2', 'Substance-1', 'Substance-2'],
+      byIds: expectedByIds,
+      pageLinks: undefined,
     });
   });
 

--- a/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
@@ -51,7 +51,7 @@ describe('substance reducer', () => {
 
     const action = {
       type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
-      substanceSearchEntries: responseNoGroup,
+      fetchedEntities: responseNoGroup,
       groupBy: 'substance',
       link: 'some-link',
     };
@@ -83,7 +83,7 @@ describe('substance reducer', () => {
 
     const action = {
       type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
-      substanceSearchEntries: responseGrouped,
+      fetchedEntities: responseGrouped,
       groupBy: 'sample_type',
       link: 'some-link',
     };
@@ -110,7 +110,7 @@ describe('substance reducer', () => {
 
     const action = {
       type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
-      substanceSearchEntries: mockResponseNoGroup,
+      fetchedEntities: mockResponseNoGroup,
       groupBy: 'substance',
       link: 'some-link',
     };
@@ -120,8 +120,8 @@ describe('substance reducer', () => {
 
     // Assert
 
-    const responseFromReducer = TestStubs.SubstanceEntriesFromReducer(2, 'substance');
-    const expectedByIds = keyBy(responseFromReducer, (entry) => entry.global_id);
+    const responseFromReducer = TestStubs.ListViewEntriesFromReducer(2, 'substance');
+    const expectedByIds = keyBy(responseFromReducer, (entry) => entry.entity.global_id);
     expect(nextState).toEqual({
       ...prevState,
       errorMessage: null,
@@ -138,7 +138,7 @@ describe('substance reducer', () => {
 
     const action = {
       type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
-      substanceSearchEntries: mockResponseGrouped,
+      fetchedEntities: mockResponseGrouped,
       link: 'some-link',
       groupBy: 'sample_type',
     };
@@ -155,13 +155,18 @@ describe('substance reducer', () => {
     // Assert
     const expectedEntryFromReducer = [
       {
-        global_id: 'Parent-1',
-        name: 'my_sample_type',
+        entity: {
+          global_id: 'Parent-1',
+          name: 'my_sample_type',
+        },
         isGroupHeader: true,
       },
     ];
 
-    const expectedByIds = keyBy(expectedEntryFromReducer, (entry) => entry.global_id);
+    const expectedByIds = keyBy(
+      expectedEntryFromReducer,
+      (entry) => entry.entity.global_id
+    );
 
     expect(nextState).toEqual({
       ...prevState,
@@ -179,7 +184,7 @@ describe('substance reducer', () => {
 
     const action = {
       type: 'SUBSTANCE_SEARCH_ENTRIES_GET_SUCCESS',
-      substanceSearchEntries: mockResponseGrouped,
+      fetchedEntities: mockResponseGrouped,
       link: 'some-link',
       groupBy: 'container',
     };
@@ -196,13 +201,18 @@ describe('substance reducer', () => {
     // Assert
     const expectedEntryFromReducer = [
       {
-        global_id: 'Container-1',
-        name: 'mycontainer',
+        entity: {
+          global_id: 'Container-1',
+          name: 'mycontainer',
+        },
         isGroupHeader: true,
       },
     ];
 
-    const expectedByIds = keyBy(expectedEntryFromReducer, (entry) => entry.global_id);
+    const expectedByIds = keyBy(
+      expectedEntryFromReducer,
+      (entry) => entry.entity.global_id
+    );
 
     expect(nextState).toEqual({
       ...prevState,

--- a/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/reducers/substanceSearchEntry.spec.jsx
@@ -161,6 +161,11 @@ describe('substance reducer', () => {
           name: 'my_sample_type',
         },
         isGroupHeader: true,
+        children: {
+          isFetched: false,
+          isExpanded: false,
+          cachedIds: [],
+        },
       },
     ];
 
@@ -207,6 +212,11 @@ describe('substance reducer', () => {
           name: 'mycontainer',
         },
         isGroupHeader: true,
+        children: {
+          isFetched: false,
+          isExpanded: false,
+          cachedIds: [],
+        }
       },
     ];
 
@@ -287,6 +297,7 @@ describe('substance reducer', () => {
       children: {
         ...parentEntry.children,
         isFetched: true,
+        isExpanded: true,
         cachedIds: mockResponseNoGroup.map((e) => {
           return e.global_id;
         }),
@@ -315,6 +326,7 @@ describe('substance reducer', () => {
       },
       children: {
         isFetched: true,
+        isExpanded: false,
         cachedIds: mockResponseNoGroup.map((e) => {
           return e.global_id;
         }),
@@ -348,12 +360,22 @@ describe('substance reducer', () => {
 
     // Assert
 
+    const updatedByIds = {
+      ...originalByIds,
+    };
+    updatedByIds[parentEntry.entity.global_id] = {
+      ...parentEntry,
+      children: {
+        ...parentEntry.children,
+        isExpanded: true,
+      },
+    };
     expect(nextState).toEqual({
       ...prevState,
       errorMessage: null,
       loading: false,
       visibleIds: ['Container-1', 'Container-2', 'Substance-1', 'Substance-2'],
-      byIds: originalByIds,
+      byIds: updatedByIds,
       pageLinks: undefined,
     });
   });
@@ -398,15 +420,23 @@ describe('substance reducer', () => {
 
     // Act
     const nextState = substanceSearchEntry(prevState, action);
-
+    const updatedByIds = {
+      ...byIds,
+    };
+    updatedByIds[parentEntry.entity.global_id] = {
+      ...parentEntry,
+      children: {
+        ...parentEntry.children,
+        isExpanded: false,
+      },
+    };
     // Assert
-
     expect(nextState).toEqual({
       ...prevState,
       errorMessage: null,
       loading: false,
       visibleIds: ['Container-1', 'Container-2'],
-      byIds: byIds,
+      byIds: updatedByIds,
       pageLinks: undefined,
     });
   });

--- a/tests/js/spec/views/__snapshots__/listview.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/listview.spec.jsx.snap
@@ -9,8 +9,7 @@ ListView {
     "columns": Array [
       Object {
         "Header": "Sample name",
-        "accessor": "name",
-        "aggregate": [Function],
+        "accessor": [Function],
         "id": "name",
       },
       Object {
@@ -26,9 +25,11 @@ ListView {
     ],
     "dataById": Object {
       "1": Object {
-        "id": 1,
+        "entity": Object {
+          "global_id": 1,
+          "name": "Zombie brain",
+        },
         "isGroupHeader": true,
-        "name": "Zombie brain",
       },
     },
     "errorMessage": "",
@@ -56,8 +57,7 @@ ListView {
           Array [
             Object {
               "Header": "Sample name",
-              "accessor": "name",
-              "aggregate": [Function],
+              "accessor": [Function],
               "id": "name",
             },
             Object {
@@ -75,9 +75,11 @@ ListView {
         dataById={
           Object {
             "1": Object {
-              "id": 1,
+              "entity": Object {
+                "global_id": 1,
+                "name": "Zombie brain",
+              },
               "isGroupHeader": true,
-              "name": "Zombie brain",
             },
           }
         }

--- a/tests/js/spec/views/__snapshots__/listview.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/listview.spec.jsx.snap
@@ -25,6 +25,11 @@ ListView {
     ],
     "dataById": Object {
       "1": Object {
+        "children": Object {
+          "cachedIds": Array [],
+          "isExpanded": false,
+          "isFetched": false,
+        },
         "entity": Object {
           "global_id": 1,
           "name": "Zombie brain",
@@ -75,6 +80,11 @@ ListView {
         dataById={
           Object {
             "1": Object {
+              "children": Object {
+                "cachedIds": Array [],
+                "isExpanded": false,
+                "isFetched": false,
+              },
               "entity": Object {
                 "global_id": 1,
                 "name": "Zombie brain",
@@ -131,7 +141,9 @@ ListView {
               </thead>
               <tbody>
                 <tr>
-                  <td>
+                  <td
+                    onClick={[Function]}
+                  >
                     <CaretRight />
                   </td>
                   <td

--- a/tests/js/spec/views/listview.spec.jsx
+++ b/tests/js/spec/views/listview.spec.jsx
@@ -7,18 +7,21 @@ describe('instantiate listview', function () {
   const oneSample = {
     dataById: {
       1: {
-        id: 1,
-        name: 'mysample',
-        location: {
-          container: {
-            name: 'mycontainer',
+        entity: {
+          global_id: 1,
+          name: 'mysample',
+          location: {
+            container: {
+              name: 'mycontainer',
+            },
+          },
+          properties: {
+            sample_type: {
+              value: 'Zombie brain',
+            },
           },
         },
-        properties: {
-          sample_type: {
-            value: 'Zombie brain',
-          },
-        },
+        isGroupHeader: false,
       },
     },
     visibleIds: [1],
@@ -27,8 +30,10 @@ describe('instantiate listview', function () {
   const oneSampleType = {
     dataById: {
       1: {
-        id: 1,
-        name: 'Zombie brain',
+        entity: {
+          global_id: 1,
+          name: 'Zombie brain',
+        },
         isGroupHeader: true,
       },
     },
@@ -39,22 +44,21 @@ describe('instantiate listview', function () {
     {
       Header: 'Sample name',
       id: 'name',
-      accessor: 'name',
-      aggregate: (vals) => '',
+      accessor: (d) => d.name,
     },
     {
       Header: 'Container',
       id: 'container',
-      accessor: (d) =>
-        d.isGroupHeader ? null : d.location ? d.location.container.name : '<No location>',
+      accessor: (d, isGroupHeader) =>
+        isGroupHeader ? null : d.location ? d.location.container.name : '<No location>',
     },
     {
       Header: 'Sample Type',
       id: 'sample_type',
-      accessor: (d) =>
-        d.isGroupHeader
+      accessor: (d, isGroupHeader) =>
+        isGroupHeader
           ? null
-          : d.properties.sample_type
+          : d.properties && d.properties.sample_type
           ? d.properties.sample_type.value
           : null,
     },

--- a/tests/js/spec/views/listview.spec.jsx
+++ b/tests/js/spec/views/listview.spec.jsx
@@ -35,6 +35,11 @@ describe('instantiate listview', function () {
           name: 'Zombie brain',
         },
         isGroupHeader: true,
+        children: {
+          isFetched: false,
+          isExpanded: false,
+          cachedIds: [],
+        },
       },
     },
     visibleIds: [1],


### PR DESCRIPTION
Purpose:
To be able to expand/collapse list view entries when grouped. This PR specificly handles substances that are grouped by sample type. 

Implementation:
Add a couple of expand/collapse events into the substanceSearchEntry action/reducer. Expanded entries are cached, so that the second time the same entry is expanded, the cache is used. 

Introduce the concept of entity and entry in substanceSearchEntry. Here. entity = raw api response, and entry = entity plus metadata, meaning for example children.isExpanded or children.cachedIds. 