### PR TITLE
389, Fix plate reference by container index

### DIFF
--- a/src/clims/services/container.py
+++ b/src/clims/services/container.py
@@ -52,6 +52,10 @@ class ContainerIndex(object):
             return cls.from_string(container, key)
         elif isinstance(key, tuple):
             return cls(container, *key)
+        elif issubclass(type(key), ContainerIndex):
+            # This has to be refactored in case there is problem
+            assert container == key.container, "containers are not matching in container index"
+            return key
         else:
             raise NotImplementedError("Can't use {} as an index".format(type(key)))
 

--- a/tests/clims/models/test_container.py
+++ b/tests/clims/models/test_container.py
@@ -86,10 +86,24 @@ class TestContainer(TestCase):
         self.register_extensible(HairSample)
 
         container = HairSampleContainer(name="cont-{}".format(uuid.uuid4()))
+        sample = HairSample(name="sample-{}".format(container.name))
 
-        container["A:1"] = HairSample(name="sample-{}".format(container.name))
+        container["A:1"] = sample
         container.save()
         assert container[(0, 0)] == container["A:1"]
+        assert container["A:1"] == sample
+
+    @pytest.mark.dev_edvard
+    def test_can_address_plate_with_plate_index(self):
+        self.register_extensible(HairSampleContainer)
+        self.register_extensible(HairSample)
+
+        container = HairSampleContainer(name="cont-{}".format(uuid.uuid4()))
+        sample = HairSample(name="sample-{}".format(container.name))
+
+        container["A:1"] = sample
+        container.save()
+        assert container[sample.location] == sample
 
     def test_can_add_samples_without_location(self):
         # Ensure one can just append directly to the container, like if it were a list


### PR DESCRIPTION
Purpose: 
Fix this kind of plate referensing:
plate_position = new PlateIndex(myplate, (0,1,0))
mycontainer[plate_position] = mysample

Points for extra concern:
I'm a bit worried that the container is part of container_index, not just the actual position. Suppose a use case: application programmer expects two plates where samples are placed identical. He wants to loop one plate and fetch corresponding contents in the other plate. So he uses plate index generated from the 1st plate, and fetch contents with plate2[plate_index]. Nothing wrong so far, but I smell bugs coming here. 

What do you think? 