### PR TITLE
376 get substances for container

### DIFF
--- a/src/clims/services/base_extensible_service.py
+++ b/src/clims/services/base_extensible_service.py
@@ -149,10 +149,10 @@ class BaseExtensibleService(object):
                 get_args['archetype__project__name'] = value
             elif key == 'latest':
                 get_args['{}'.format(key)] = value
-            elif key.startswith('properties'):
-                get_args[key] = value
-            else:
+            elif key == 'id':
                 get_args['archetype__{}'.format(key)] = value
+            else:
+                get_args['{}'.format(key)] = value
         return get_args
 
     @classmethod

--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -438,6 +438,9 @@ class SubstanceQueryBuilder(BaseQueryBuilder):
         elif key == 'substance.sample_type':
             query_params['properties__extensible_property_type__name'] = 'sample_type'
             query_params['properties__string_value'] = val
+        elif key == "substance.container":
+            query_params['archetype__locations__current'] = True
+            query_params['archetype__locations__container__name'] = val
         else:
             raise NotImplementedError("The key {} is not implemented".format(key))
         return query_params

--- a/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
+++ b/src/sentry/static/sentry/app/redux/actions/substanceSearchEntry.js
@@ -71,7 +71,9 @@ export const substanceSearchEntryExpandCached = (parentEntry) => {
   };
 };
 
-export const substanceSearchEntryExpandCollapse = (parentEntry) => (dispatch) => {
+export const substanceSearchEntryExpandCollapse = (parentEntry, searchKey) => (
+  dispatch
+) => {
   dispatch(substanceSearchEntryExpandCollapseRequest(parentEntry));
   if (parentEntry.children.isExpanded) {
     return dispatch(substanceSearchEntryCollapse(parentEntry));
@@ -80,7 +82,7 @@ export const substanceSearchEntryExpandCollapse = (parentEntry) => (dispatch) =>
   } else {
     const request = {
       params: {
-        search: 'substance.sample_type:' + parentEntry.entity.name,
+        search: 'substance.' + searchKey + ':' + parentEntry.entity.name,
       },
     };
     return axios

--- a/src/sentry/static/sentry/app/views/substances/substances.jsx
+++ b/src/sentry/static/sentry/app/views/substances/substances.jsx
@@ -27,6 +27,7 @@ class Substances extends React.Component {
     this.onSearch = this.onSearch.bind(this);
     this.toggleAll = this.toggleAll.bind(this);
     this.onCursor = this.onCursor.bind(this);
+    this.expandCollapse = this.expandCollapse.bind(this);
 
     let {search, cursor, groupBy} = this.props.substanceSearchEntry;
     const query = this.props.location.query;
@@ -148,6 +149,11 @@ class Substances extends React.Component {
     );
   }
 
+  expandCollapse(parentEntry) {
+    let {groupBy} = this.props.substanceSearchEntry;
+    this.props.substanceSearchEntryExpandCollapse(parentEntry, groupBy);
+  }
+
   render() {
     // TODO: Rename css classes to something else than stream
     const groupOptions = [
@@ -194,7 +200,7 @@ class Substances extends React.Component {
             toggleAll={this.toggleAll}
             toggleSingle={this.props.substanceSearchEntryToggleSelect}
             listActionBar={actionBar}
-            expandCollapse={this.props.substanceSearchEntryExpandCollapse}
+            expandCollapse={this.expandCollapse}
           />
 
           {this.props.substanceSearchEntry.paginationEnabled &&
@@ -239,8 +245,8 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(substanceSearchEntriesToggleSelectAll(doSelect)),
   substanceSearchEntryToggleSelect: (id, doSelect) =>
     dispatch(substanceSearchEntryToggleSelect(id, doSelect)),
-  substanceSearchEntryExpandCollapse: (parentEntry) =>
-    dispatch(substanceSearchEntryExpandCollapse(parentEntry)),
+  substanceSearchEntryExpandCollapse: (parentEntry, searchKey) =>
+    dispatch(substanceSearchEntryExpandCollapse(parentEntry, searchKey)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Substances);

--- a/tests/clims/api/endpoints/test_substances.py
+++ b/tests/clims/api/endpoints/test_substances.py
@@ -10,7 +10,7 @@ from sentry.testutils import APITestCase
 
 from rest_framework import status
 from clims.models.substance import Substance
-from tests.fixtures.plugins.gemstones_inc.models import GemstoneSample
+from tests.fixtures.plugins.gemstones_inc.models import GemstoneSample, GemstoneContainer
 
 
 class SubstancesTest(APITestCase):
@@ -23,6 +23,7 @@ class SubstancesTest(APITestCase):
     def test_search_substances_find_single_by_name(self):
         # NOTE: For now, the search is always using wildcards. This will be ported to using
         # elastic in milestone 2.
+        # Arrange
         sample = self.create_gemstone(color='red')
         sample.color = 'blue'
         sample.save()
@@ -34,19 +35,28 @@ class SubstancesTest(APITestCase):
 
         url = reverse('clims-api-0-substances', args=(sample.organization.name,))
         self.login_as(self.user)
+
+        # Act
         response = self.client.get(url + '?search=' + search)
+
+        # Assert
         assert response.status_code == 200, response.content
         # The search is for a unique name, so this must be true:
         assert len(response.data) == 1, len(response.data)
 
     def test_get_substances(self):
+        # Arrange
         first = self.create_gemstone(color='red')
         first.color = 'blue'
         first.save()
 
         url = reverse('clims-api-0-substances', args=(first.organization.name,))
         self.login_as(self.user)
+
+        # Act
         response = self.client.get(url)
+
+        # Assert
         len_before = len(response.data)
 
         second = self.create_gemstone()
@@ -73,15 +83,48 @@ class SubstancesTest(APITestCase):
         asserts(first, data_by_id[first.id])
         asserts(second, data_by_id[second.id])
 
-    @pytest.mark.dev_edvard
     def test_filter_substances_on_property(self):
+        # Arrange
         stone1 = self.create_gemstone(color='red')
         self.create_gemstone(color='blue')
 
         url = reverse('clims-api-0-substances', args=(self.organization.name,))
         self.login_as(self.user)
+
+        # Act
         response = self.client.get(url + '?search=substance.color:red')
 
+        # Assert
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        data_by_id = {int(entry['id']): entry for entry in response.data}
+
+        def asserts(sample, response):
+            properties = response.pop('properties')
+            assert properties['color']['value'] == sample.properties['color'].value
+            assert response == dict(
+                name=sample.name,
+                version=sample.version,
+                id=sample.id,
+                type_full_name=sample.type_full_name,
+                location=None,
+                global_id="Substance-{}".format(sample.id),
+            )
+
+        asserts(stone1, data_by_id[stone1.id])
+
+    def test_filter_substances_on_property__with_spaces(self):
+        # Arrange
+        stone1 = self.create_gemstone(color='red red')
+        self.create_gemstone(color='blue')
+
+        url = reverse('clims-api-0-substances', args=(self.organization.name,))
+        self.login_as(self.user)
+
+        # Act
+        response = self.client.get(url + '?search=substance.color:red red')
+
+        # Assert
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         data_by_id = {int(entry['id']): entry for entry in response.data}
@@ -101,19 +144,27 @@ class SubstancesTest(APITestCase):
         asserts(stone1, data_by_id[stone1.id])
 
     @pytest.mark.dev_edvard
-    def test_filter_substances_on_property__with_spaces(self):
-        stone1 = self.create_gemstone(color='red red')
+    def test_filter_substances_on_container(self):
+        # Arrange
+        container = self.create_container(GemstoneContainer, name='mycontainer')
+        stone1 = self.create_gemstone(color='red')
+        container.append(stone1)
+        container.save()
         self.create_gemstone(color='blue')
-
         url = reverse('clims-api-0-substances', args=(self.organization.name,))
         self.login_as(self.user)
-        response = self.client.get(url + '?search=substance.color:red red')
 
+        # Act
+        response = self.client.get(url + '?search=substance.container:mycontainer')
+
+        # Assert
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         data_by_id = {int(entry['id']): entry for entry in response.data}
 
         def asserts(sample, response):
+            from clims.api.serializers.models.substance import SubstanceSerializer
+            serialized_sample = SubstanceSerializer(sample)
             properties = response.pop('properties')
             assert properties['color']['value'] == sample.properties['color'].value
             assert response == dict(
@@ -121,14 +172,14 @@ class SubstancesTest(APITestCase):
                 version=sample.version,
                 id=sample.id,
                 type_full_name=sample.type_full_name,
-                location=None,
+                location=serialized_sample.data['location'],
                 global_id="Substance-{}".format(sample.id),
             )
 
         asserts(stone1, data_by_id[stone1.id])
 
     def test_post_substance(self):
-        # Setup
+        # Arrange
         extensible_type = self.register_extensible(GemstoneSample)
 
         url = reverse('clims-api-0-substances', args=(self.organization.slug,))
@@ -138,16 +189,16 @@ class SubstancesTest(APITestCase):
             "properties": {'color': 'red'},
             "type_full_name": extensible_type.name
         }
-
-        # Test
         self.login_as(self.user)
+
+        # Act
         response = self.client.post(
             path=url,
             data=json.dumps(payload),
             content_type='application/json',
         )
 
-        # Validate
+        # Assert
         assert response.status_code == status.HTTP_201_CREATED, response.data
         created_id = response.data["id"]
 

--- a/tests/clims/models/test_container.py
+++ b/tests/clims/models/test_container.py
@@ -35,6 +35,7 @@ class TestContainer(TestCase):
         with pytest.raises(IntegrityError):
             container2.save()
 
+    @pytest.mark.dev_edvard
     def test_can_add_custom_property(self):
         self.register_extensible(HairSampleContainer)
         container = HairSampleContainer(name="container1")

--- a/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
+++ b/tests/js/spec/redux/actions/substanceSearchEntry.spec.jsx
@@ -154,14 +154,65 @@ describe('substance redux actions', function () {
         },
       ];
 
+      const searchKey = 'sample_type';
       // TODO: return
-      return store.dispatch(substanceSearchEntryExpandCollapse(parentEntry)).then(() => {
-        expect(store.getActions()).toEqual(expectedActions);
-        const request = moxios.requests.mostRecent();
-        expect(request.url).toBe(
-          '/api/0/organizations/lab/substances/?search=substance.sample_type:fang'
-        );
-      });
+      return store
+        .dispatch(substanceSearchEntryExpandCollapse(parentEntry, searchKey))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+          const request = moxios.requests.mostRecent();
+          expect(request.url).toBe(
+            '/api/0/organizations/lab/substances/?search=substance.sample_type:fang'
+          );
+        });
+    });
+
+    it('should handle un-cached expand of container', async () => {
+      const fetchedEntities = mockResponseNoGroup;
+      const store = mockStore({substances: []});
+
+      moxios.stubRequest(
+        '/api/0/organizations/lab/substances/?search=substance.container:cont1',
+        {
+          status: 200,
+          responseText: fetchedEntities,
+          headers: [],
+        }
+      );
+
+      const parentEntry = {
+        entity: {
+          name: 'cont1',
+          global_id: 'Parent-1',
+        },
+        children: {
+          isFetched: false,
+        },
+      };
+
+      const expectedActions = [
+        {
+          type: SUBSTANCE_SEARCH_ENTRY_EXPAND_COLLAPSE_REQUEST,
+          parentEntry,
+        },
+        {
+          type: SUBSTANCE_SEARCH_ENTRY_EXPAND_SUCCESS,
+          fetchedEntities,
+          parentEntry,
+        },
+      ];
+
+      const searchKey = 'container';
+      // TODO: return
+      return store
+        .dispatch(substanceSearchEntryExpandCollapse(parentEntry, searchKey))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+          const request = moxios.requests.mostRecent();
+          expect(request.url).toBe(
+            '/api/0/organizations/lab/substances/?search=substance.container:cont1'
+          );
+        });
     });
 
     it('should create an action to collapse children from parent entry', async () => {


### PR DESCRIPTION
Purpose:
Complete the expandable list view to be able to expand/collapse containers, when samples are grouped by containers (not just sample types). 

Implementation:
Enhance the substance api resource to recognize the "substance.container" key word. In UI, call the expand-collapse action with the current "groupby" value.