### PR TITLE
fix substance location

### DIFF
--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -151,11 +151,22 @@ class HasLocationMixin(object):
         self._new_location = (container, x, y, z)
         self.is_dirty = True
 
+    def _reset_previous_locations(self):
+        # reset "current" flag on previous location instances
+        previous_locations = SubstanceLocation.objects.filter(
+            substance=self._wrapped_version.archetype,
+            current=True,
+        )
+        for loc in previous_locations:
+            loc.current = False
+            loc.save()
+
     def _save_location(self):
         """
         Saves the current location. Needs to be called in any class that uses this mixin.
         """
         if self._new_location:
+            self._reset_previous_locations()
             container, x, y, z = self._new_location
             new_location = SubstanceLocation(
                 container=container._wrapped_version.archetype,

--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -149,6 +149,7 @@ class HasLocationMixin(object):
         # in the end
         x, y, z = index
         self._new_location = (container, x, y, z)
+        self.is_dirty = True
 
     def _save_location(self):
         """
@@ -430,6 +431,7 @@ class ExtensibleBase(ExtensibleCore):
             self._archetype.save()
 
         self._save_custom(creating)
+        self.is_dirty = False
 
     @property
     def id(self):

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -86,7 +86,6 @@ class SubstancePropertiesTestCase(TestCase):
         assert fetched_sample.cool == cool
         assert fetched_sample.erudite == erudite
 
-    @pytest.mark.dev_edvard
     def test_set_text_property_to_none__with_nullable_field__it_works(self):
         name = "sample-{}".format(random.randint(1, 1000000))
 
@@ -97,7 +96,6 @@ class SubstancePropertiesTestCase(TestCase):
         fetched_sample = self.app.substances.get(name=sample.name)
         assert fetched_sample.mox_feeling is None
 
-    @pytest.mark.dev_edvard
     def test_set_text_property_to_none__with_not_nullable_field__exception(self):
         name = "sample-{}".format(random.randint(1, 1000000))
 
@@ -146,7 +144,6 @@ class TestSubstance(SubstanceTestCase):
         expected = {(1, original_name), (2, substance.name)}
         assert actual == expected
 
-    @pytest.mark.dev_edvard
     def test_update_name__the_new_name_is_searchable(self):
         # Arrange
         substance = self.create_gemstone()
@@ -454,6 +451,15 @@ class TestSubstance(SubstanceTestCase):
         #       Then it would be enough to check first.location == "a1" and we could return
         #       this directly to the frontend
         assert (first.location.x, first.location.y, first.location.z) == (0, 0, 0)
+
+    @pytest.mark.dev_edvard
+    def test_location_is_set_twice__location_is_still_accessible(self):
+        container = self.create_container_with_samples(GemstoneContainer, GemstoneSample)
+        first = container["a1"]
+        new_position = (0, 0, 0)
+        first.move(container, new_position)
+        first.save()
+        assert first.location is not None
 
     def test_with_no_display_name__default_display_name_is_shown(self):
         self.register_extensible(QuirkSample)

--- a/tests/clims/models/test_substance_child.py
+++ b/tests/clims/models/test_substance_child.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
-
+import pytest
 from clims.models import Substance
 from tests.clims.models.test_substance import SubstanceTestCase
+from tests.fixtures.plugins.gemstones_inc.models import GemstoneContainer
 
 
 class TestSubstanceParentChild(SubstanceTestCase):
@@ -17,6 +18,23 @@ class TestSubstanceParentChild(SubstanceTestCase):
     def test_original_substance_has_no_parent(self):
         sample = self.create_gemstone()
         assert len(sample.parents) == 0
+
+    @pytest.mark.dev_edvard
+    def test_can_add_child_to_new_container(self):
+        # Arrange
+        parent = self.create_gemstone(name='parent')
+        parent_container = self.create_container(GemstoneContainer, name='parent_container')
+        parent_container.append(parent)
+        parent_container.save()
+        assert parent.location is not None
+        child = parent.create_child(name='child')
+        child_container = self.create_container(GemstoneContainer, name='child-container')
+        child_container.append(child)
+        child_container.save()
+        contents = list(child_container.contents)
+        print(contents[0].name)
+        print(child_container._locatables)
+        assert child.location is not None
 
     def test_children_get_increased_depth(self):
         original = self.create_gemstone()


### PR DESCRIPTION
Purpose:
This fixes a bug that showed up when saving a substance location twice. Then there were two locations in db, both with current flag = true, which caused an error when retrieving substance.location. 