### PR TITLE
clims-407, add handling for project in substance.create_child()

### DIFF
--- a/src/clims/services/substance.py
+++ b/src/clims/services/substance.py
@@ -241,7 +241,7 @@ class SubstanceBase(HasLocationMixin, ExtensibleBase):
         self._save_location()
 
     @transaction.atomic
-    def create_child(self, name=None, **kwargs):
+    def create_child(self, name=None, project=None, **kwargs):
         """
         Creates a child from this substance, giving it a name. If name is not supplied it
         will get a unique name based on the name of the parent.
@@ -299,7 +299,14 @@ class SubstanceBase(HasLocationMixin, ExtensibleBase):
             prop.save()
             version.properties.add(prop)
 
-        return self._app.substances.to_wrapper(child)
+        # Handle project
+        child_realization = self._app.substances.to_wrapper(child)
+        child_project = project or self.project
+        if child_project:
+            child_realization.project = child_project
+            child_realization.save()
+
+        return child_realization
 
 
 class SubstanceService(BaseExtensibleService):

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -10,13 +10,15 @@ from clims.services.substance import SubstanceBase
 from clims.services.extensible import FloatField
 from clims.services.extensible import TextField
 from django.db import IntegrityError
-from tests.fixtures.plugins.gemstones_inc.models import GemstoneSample, GemstoneContainer
+from tests.fixtures.plugins.gemstones_inc.models import \
+    GemstoneSample, GemstoneContainer, GemstoneProject
 
 
 class SubstanceTestCase(TestCase):
     # Expose these types to the testcase so imports are not required
     GemstoneSample = GemstoneSample
     GemstoneContainer = GemstoneContainer
+    GemstoneProject = GemstoneProject
 
     def setUp(self):
         self.register_extensible(GemstoneSample)
@@ -27,6 +29,9 @@ class SubstanceTestCase(TestCase):
 
     def create_gemstone_container(self, *args, **kwargs):
         return self.create_container(GemstoneContainer, *args, **kwargs)
+
+    def create_gemstone_project(self, *args, **kwargs):
+        return self.create_clims_project(GemstoneProject, *args, **kwargs)
 
     def register_gemstone_type(self):
         return self.register_extensible(GemstoneSample)

--- a/tests/clims/models/test_substance_child.py
+++ b/tests/clims/models/test_substance_child.py
@@ -19,9 +19,7 @@ class TestSubstanceParentChild(SubstanceTestCase):
         sample = self.create_gemstone()
         assert len(sample.parents) == 0
 
-    @pytest.mark.dev_edvard
     def test_can_add_child_to_new_container(self):
-        # Arrange
         parent = self.create_gemstone(name='parent')
         parent_container = self.create_container(GemstoneContainer, name='parent_container')
         parent_container.append(parent)
@@ -31,10 +29,26 @@ class TestSubstanceParentChild(SubstanceTestCase):
         child_container = self.create_container(GemstoneContainer, name='child-container')
         child_container.append(child)
         child_container.save()
-        contents = list(child_container.contents)
-        print(contents[0].name)
-        print(child_container._locatables)
         assert child.location is not None
+
+    @pytest.mark.dev_edvard
+    def test__project_is_included_by_default(self):
+        parent_project = self.create_gemstone_project(continent='europe')
+        parent = self.create_gemstone(name='parent', project=parent_project)
+        child = parent.create_child()
+        assert child.project.continent == 'europe'
+
+    def test__project_added_as_input__default_is_overridden(self):
+        new_project = self.create_gemstone_project(continent='asia')
+        parent_project = self.create_gemstone_project(continent='europe')
+        parent = self.create_gemstone(name='parent', project=parent_project)
+        child = parent.create_child(project=new_project)
+        assert child.project.continent == 'asia'
+
+    def test__parent_has_no_project__child_has_no_project(self):
+        parent = self.create_gemstone(name='parent')
+        child = parent.create_child()
+        assert child.project is None
 
     def test_children_get_increased_depth(self):
         original = self.create_gemstone()


### PR DESCRIPTION
By default, create_child() inherits the parent's project. Project may also be overridden. 