### PR TITLE
clims-427, Include extensible properties from base classes

### DIFF
--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -73,13 +73,21 @@ class ExtensibleService(object):
                 self._implementations[full_name] = ext_class
         return self._implementations
 
+    def _list_all_cls_attributes_rec(self, cls, seed):
+        for b in cls.__bases__:
+            seed = self._list_all_cls_attributes_rec(b, seed)
+        seed.update(cls.__dict__)
+        return seed
+
     def register(self, plugin_reg, extensible_base):
         logger.info("Installing '{}' from plugin '{}@{}'".format(
             utils.class_full_name(extensible_base), plugin_reg.name,
             plugin_reg.version))
 
         property_types = list()
-        for field in extensible_base.__dict__.values():
+        seed = dict()
+        cls_attributes = self._list_all_cls_attributes_rec(extensible_base, seed)
+        for field in cls_attributes.values():
             if not isinstance(field, ExtensibleBaseField):
                 continue
 

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -11,7 +11,7 @@ from clims.services.extensible import FloatField
 from clims.services.extensible import TextField
 from django.db import IntegrityError
 from tests.fixtures.plugins.gemstones_inc.models import \
-    GemstoneSample, GemstoneContainer, GemstoneProject
+    GemstoneSample, GemstoneContainer, GemstoneProject, InheritedSample
 
 
 class SubstanceTestCase(TestCase):
@@ -127,6 +127,14 @@ class SubstancePropertiesTestCase(TestCase):
 class TestSubstance(SubstanceTestCase):
     def setUp(self):
         self.has_context()
+
+    @pytest.mark.dev_edvard
+    def test_gemstone_inheritance(self):
+        self.register_extensible(InheritedSample)
+        sample = InheritedSample(name='sample1')
+        sample.save()
+        sample.color = 'blue'
+        assert sample.color == 'blue'
 
     def test_can_create_substance(self):
         substance = self.create_gemstone()
@@ -349,7 +357,6 @@ class TestSubstance(SubstanceTestCase):
         sample = self.create_gemstone(color='red')
         sample.weight = 10
 
-    @pytest.mark.dev_edvard
     def test_assign_zero_to_int_field_succeeds(self):
         sample = self.create_gemstone()
         sample.weight = 0
@@ -486,7 +493,6 @@ class TestSubstance(SubstanceTestCase):
         first.save()
         assert first.location is not None
 
-    @pytest.mark.dev_edvard
     def test_location_changed_after_a_fetch__update_is_ok(self):
         container = self.create_container_with_samples(GemstoneContainer, GemstoneSample)
         first = container["a1"]

--- a/tests/fixtures/plugins/gemstones_inc/models.py
+++ b/tests/fixtures/plugins/gemstones_inc/models.py
@@ -17,6 +17,10 @@ class GemstoneSample(SubstanceBase):
     has_something = BoolField()
 
 
+class InheritedSample(GemstoneSample):
+    pass
+
+
 class GemstoneContainer(PlateBase):
     # This will lead `container.add(name="sample1")` to use GemstoneSample rather than the
     # basic SubstanceBase. You can still add other types of "locatables", like another sample type


### PR DESCRIPTION
Purpose:

Make possible to have class inheritance for extensible classes:

Example:
BaseSample(SubstanceBase):
  concentration = FloatField()

RmlSample(BaseSample):
 pass

sample = RmlSample()
sample.concentration = 10