### PR TITLE
Send POST request with action creators

### DIFF
--- a/src/sentry/static/sentry/app/redux/actions/shared.js
+++ b/src/sentry/static/sentry/app/redux/actions/shared.js
@@ -71,26 +71,17 @@ const acCreateFailure = (resource) =>
   makeActionCreator(`CREATE_${resource}_FAILURE`, 'statusCode', 'message');
 
 const acCreate = (resource, urlTemplate) => {
-  return (org, data, redirect) => (dispatch) => {
-    dispatch(acCreateRequest(resource)());
+  return (org, data) => (dispatch) => {
+    dispatch(acCreateRequest(resource)(data));
 
-    const api = new Client();
     const url = urlTemplate.replace('{org}', org.slug);
 
-    api.request(url, {
-      method: 'POST',
-      data,
-      success: (res) => {
-        dispatch(acCreateSuccess(resource)(res));
-        const createdId = res.workBatch.id; // TODO-nocommit
-        if (redirect) {
-          browserHistory.push(`/${org.slug}/workbatches/${createdId}/`); // TODO-NOCOMMIT: configurable in creator
-        }
-      },
-      error: (err) => {
-        dispatch(acCreateFailure(resource)(err.statusCode, err.statusText));
-      },
-    });
+    return axios
+      .post(url, data)
+      .then(() => dispatch(acCreateSuccess(resource)(data)))
+      .catch((err) =>
+        dispatch(acCreateFailure(resource)(err.statusCode, err.statusText))
+      );
   };
 };
 


### PR DESCRIPTION
Purpose:
Include action creator POST requests in tests. 

Implementation:
Call POST by axios.post() so that it may be mocked in tests. 