### PR TITLE
447 show buttons in workbatch according to configuration

### DIFF
--- a/src/sentry/static/sentry/app/redux/actions/shared.js
+++ b/src/sentry/static/sentry/app/redux/actions/shared.js
@@ -95,10 +95,10 @@ const acGetFailure = (resource) =>
   makeActionCreator(`GET_${resource}_FAILURE`, 'statusCode', 'message');
 
 const acGet = (resource, urlTemplate) => {
-  return (id) => (dispatch) => {
+  return (org, id) => (dispatch) => {
     dispatch(acGetRequest(resource)(id));
-
-    const url = urlTemplate.replace('{id}', id);
+    let url = urlTemplate.replace('{org}', org.slug);
+    url = url.replace('{id}', id + '/');
     return axios
       .get(url)
       .then((res) => dispatch(acGetSuccess(resource)(res.data)))

--- a/src/sentry/static/sentry/app/redux/actions/workBatchDetails.js
+++ b/src/sentry/static/sentry/app/redux/actions/workBatchDetails.js
@@ -1,15 +1,16 @@
-// import axios from 'axios';
+import axios from 'axios';
 // import {Client} from 'app/api';
 
 export const WORK_BATCH_DETAILS_GET_REQUEST = 'WORK_BATCH_DETAILS_GET_REQUEST';
-export const getWorkBatchDetailsRequest = () => {
+export const workBatchDetailsGetRequest = (id) => {
   return {
     type: WORK_BATCH_DETAILS_GET_REQUEST,
+    id,
   };
 };
 
 export const WORK_BATCH_DETAILS_GET_SUCCESS = 'WORK_BATCH_DETAILS_GET_SUCCESS';
-export const getWorkBatchDetailsSuccess = (workBatch) => {
+export const workBatchDetailsGetSuccess = (workBatch) => {
   return {
     type: WORK_BATCH_DETAILS_GET_SUCCESS,
     workBatch,
@@ -17,13 +18,13 @@ export const getWorkBatchDetailsSuccess = (workBatch) => {
 };
 
 export const WORK_BATCH_DETAILS_GET_FAILURE = 'WORK_BATCH_DETAILS_GET_FAILURE';
-export const getWorkBatchDetailsFailure = (err) => ({
+export const workBatchDetailsGetFailure = (err) => ({
   type: WORK_BATCH_DETAILS_GET_FAILURE,
   message: err,
 });
 
 export const getWorkBatchDetails = (org, id) => (dispatch) => {
-  dispatch(getWorkBatchDetailsRequest());
+  dispatch(workBatchDetailsGetRequest(id));
   // A) Fetch the work batch itself and B) fetch the setting for it if we don't already have it
   // TODO: for that kind of thing to work, we need to join the reducers!
 
@@ -152,10 +153,10 @@ export const getWorkBatchDetails = (org, id) => (dispatch) => {
   };
 
   // TODO: hook up with bakend
-  dispatch(getWorkBatchDetailsSuccess(data));
+  // dispatch(getWorkBatchDetailsSuccess(data));
 
-  // return axios
-  //   .get(`/api/0/organizations/${org}/work-batches/${id}`)
-  //   .then(res => dispatch(workBatchDetailsGetSuccess(res.data)))
-  //   .catch(err => dispatch(workBatchDetailsGetFailure(err)));
+  return axios
+    .get(`/api/0/organizations/${org}/workbatch-details/${id}`)
+    .then((res) => dispatch(workBatchDetailsGetSuccess(res.data)))
+    .catch((err) => dispatch(workBatchDetailsGetFailure(err)));
 };

--- a/src/sentry/static/sentry/app/redux/reducers/index.js
+++ b/src/sentry/static/sentry/app/redux/reducers/index.js
@@ -11,6 +11,18 @@ import taskDefinition from './taskDefinition';
 import workBatch from './workBatch';
 import workBatchDetails from './workBatchDetails';
 import projectSearchEntry from './projectSearchEntry';
+import {resource} from './shared';
+
+const sharedInitialState = {
+  ...resource.initialState,
+};
+
+export const WORK_CONFIGURATION = 'WORK_CONFIGURATION';
+
+const workConfigurationEntry = resource.createReducer(
+  WORK_CONFIGURATION,
+  sharedInitialState
+);
 
 export default combineReducers({
   process,
@@ -24,4 +36,5 @@ export default combineReducers({
   workBatch,
   workBatchDetails,
   projectSearchEntry,
+  workConfigurationEntry,
 });

--- a/src/sentry/static/sentry/app/redux/reducers/index.js
+++ b/src/sentry/static/sentry/app/redux/reducers/index.js
@@ -18,6 +18,7 @@ const sharedInitialState = {
 };
 
 export const WORK_CONFIGURATION = 'WORK_CONFIGURATION';
+export const EVENTS = 'EVENTS';
 
 const workConfigurationEntry = resource.createReducer(
   WORK_CONFIGURATION,

--- a/src/sentry/static/sentry/app/redux/reducers/index.js
+++ b/src/sentry/static/sentry/app/redux/reducers/index.js
@@ -17,13 +17,10 @@ const sharedInitialState = {
   ...resource.initialState,
 };
 
-export const WORK_CONFIGURATION = 'WORK_CONFIGURATION';
+export const WORK_DEFINITION = 'WORK_DEFINITION';
 export const EVENTS = 'EVENTS';
 
-const workConfigurationEntry = resource.createReducer(
-  WORK_CONFIGURATION,
-  sharedInitialState
-);
+const workDefinitionEntry = resource.createReducer(WORK_DEFINITION, sharedInitialState);
 
 export default combineReducers({
   process,
@@ -37,5 +34,5 @@ export default combineReducers({
   workBatch,
   workBatchDetails,
   projectSearchEntry,
-  workConfigurationEntry,
+  workDefinitionEntry,
 });

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -21,7 +21,7 @@ import errorHandler from 'app/utils/errorHandler';
 
 // CLIMS
 import SubstancesContainer from 'app/views/substances/index';
-import ExampleWorkbatchContainer from 'app/views/exampleWorkbatch/index';
+import WorkBatchDetailsWaitingToBeMergedContainer from 'app/views/workBatchDetailsWaitingToBeMerged/index';
 import ProjectsContainer from 'app/views/projects/index';
 import WorkBatchListContainer from 'app/views/workBatchList/index';
 import WorkBatchDetailsContainer from 'app/views/workBatchDetails/organization/index';
@@ -606,8 +606,8 @@ function routes() {
           <Route path="work-batches/" component={errorHandler(WorkBatchListContainer)} />
           <Route path="substances/" component={errorHandler(SubstancesContainer)} />
           <Route
-            path="example-workbatch/"
-            component={errorHandler(ExampleWorkbatchContainer)}
+            path="workbatch-details/"
+            component={errorHandler(WorkBatchDetailsWaitingToBeMergedContainer)}
           />
 
           <Route

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -21,6 +21,7 @@ import errorHandler from 'app/utils/errorHandler';
 
 // CLIMS
 import SubstancesContainer from 'app/views/substances/index';
+import ExampleWorkbatchContainer from 'app/views/exampleWorkbatch/index';
 import ProjectsContainer from 'app/views/projects/index';
 import WorkBatchListContainer from 'app/views/workBatchList/index';
 import WorkBatchDetailsContainer from 'app/views/workBatchDetails/organization/index';
@@ -604,6 +605,10 @@ function routes() {
           />
           <Route path="work-batches/" component={errorHandler(WorkBatchListContainer)} />
           <Route path="substances/" component={errorHandler(SubstancesContainer)} />
+          <Route
+            path="example-workbatch/"
+            component={errorHandler(ExampleWorkbatchContainer)}
+          />
 
           <Route
             path="workbatches/:groupId/"

--- a/src/sentry/static/sentry/app/views/exampleWorkbatch/index.jsx
+++ b/src/sentry/static/sentry/app/views/exampleWorkbatch/index.jsx
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {resourceActionCreators} from 'app/redux/actions/shared';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import moxios from 'moxios';
-import {WORK_CONFIGURATION} from 'app/redux/reducers/index';
+import {WORK_CONFIGURATION, EVENTS} from 'app/redux/reducers/index';
 
 class ExampleWorkbatchContainer extends React.Component {
   constructor(props) {
@@ -47,7 +47,13 @@ class ExampleWorkbatchContainer extends React.Component {
     );
   }
 
-  sendButtonClickedEvent(clickedButtonName, workBatchId) {}
+  sendButtonClickedEvent(clickedButtonName, workBatchId) {
+    const buttonEvent = {
+      event: clickedButtonName,
+      workBatchId,
+    };
+    this.props.sendButtonClickedEvent(this.props.organization, buttonEvent);
+  }
 }
 
 ExampleWorkbatchContainer.propTypes = {
@@ -75,6 +81,14 @@ const mockedWorkConfiguration = {
   ],
 };
 const mapDispatchToProps = (dispatch) => ({
+  sendButtonClickedEvent: (org, buttonEvent) => {
+    const urlTemplate = '/api/0/organizations/{org}/events/';
+    const sendButtonClickedEventRoutine = resourceActionCreators.acCreate(
+      EVENTS,
+      urlTemplate
+    );
+    dispatch(sendButtonClickedEventRoutine(org, buttonEvent));
+  },
   getWorkConfiguration: (org, id) => {
     const urlTemplate = '/api/0/organizations/{org}/work-configrations/';
     const getWorkConfigurationRoutine = resourceActionCreators.acGet(

--- a/src/sentry/static/sentry/app/views/exampleWorkbatch/index.jsx
+++ b/src/sentry/static/sentry/app/views/exampleWorkbatch/index.jsx
@@ -5,12 +5,12 @@ import {connect} from 'react-redux';
 import {resourceActionCreators} from 'app/redux/actions/shared';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import moxios from 'moxios';
-import {WORK_CONFIGURATION, EVENTS} from 'app/redux/reducers/index';
+import {WORK_DEFINITION, EVENTS} from 'app/redux/reducers/index';
 
 class ExampleWorkbatchContainer extends React.Component {
   constructor(props) {
     super(props);
-    this.props.getWorkConfiguration(
+    this.props.getWorkDefinition(
       this.props.organization,
       'clims.plugins.demo.dnaseq.configuration.my_fancy_step.MyFancyStep'
     );
@@ -18,17 +18,17 @@ class ExampleWorkbatchContainer extends React.Component {
 
   render() {
     const buttonsFromConfig = [];
-    let workConfigurationEntry = this.props.workConfigurationEntry;
-    if (workConfigurationEntry == null) {
+    let workDefinitionEntry = this.props.workDefinitionEntry;
+    if (workDefinitionEntry == null) {
       return <LoadingIndicator />;
     }
-    let {byIds, detailsId} = workConfigurationEntry;
+    let {byIds, detailsId} = workDefinitionEntry;
     if (detailsId == null) {
       return <LoadingIndicator />;
     }
-    const workConfiguration = byIds[detailsId];
-    let {buttons: buttonConfigurations, id: configId} = workConfiguration;
-    for (const entry of buttonConfigurations) {
+    const workDefinition = byIds[detailsId];
+    let {buttons: buttonDefinitions, id: configId} = workDefinition;
+    for (const entry of buttonDefinitions) {
       const buttonClick = () => {
         this.sendButtonClickedEvent(entry.name, configId);
       };
@@ -66,11 +66,11 @@ ExampleWorkbatchContainer.propTypes = {
 
 const mapStateToProps = (state) => {
   return {
-    workConfigurationEntry: state.workConfigurationEntry,
+    workDefinitionEntry: state.workDefinitionEntry,
   };
 };
 
-const mockedWorkConfiguration = {
+const mockedWorkDefinition = {
   id: 2,
   buttons: [
     {
@@ -92,10 +92,10 @@ const mapDispatchToProps = (dispatch) => ({
     );
     dispatch(sendButtonClickedEventRoutine(org, buttonEvent));
   },
-  getWorkConfiguration: (org, cls_full_name) => {
+  getWorkDefinition: (org, cls_full_name) => {
     const urlTemplate = '/api/0/organizations/{org}/work-definition-details/{id}';
-    const getWorkConfigurationRoutine = resourceActionCreators.acGet(
-      WORK_CONFIGURATION,
+    const getWorkDefinitionRoutine = resourceActionCreators.acGet(
+      WORK_DEFINITION,
       urlTemplate
     );
     // TODO: remove this mock response
@@ -104,11 +104,11 @@ const mapDispatchToProps = (dispatch) => ({
       const request = moxios.requests.mostRecent();
       request.respondWith({
         status: 200,
-        response: mockedWorkConfiguration,
+        response: mockedWorkDefinition,
         headers: [],
       });
     });
-    dispatch(getWorkConfigurationRoutine(org, id));
+    dispatch(getWorkDefinitionRoutine(org, cls_full_name));
   },
 });
 

--- a/src/sentry/static/sentry/app/views/exampleWorkbatch/index.jsx
+++ b/src/sentry/static/sentry/app/views/exampleWorkbatch/index.jsx
@@ -10,7 +10,10 @@ import {WORK_CONFIGURATION, EVENTS} from 'app/redux/reducers/index';
 class ExampleWorkbatchContainer extends React.Component {
   constructor(props) {
     super(props);
-    this.props.getWorkConfiguration(this.props.organization, 2);
+    this.props.getWorkConfiguration(
+      this.props.organization,
+      'clims.plugins.demo.dnaseq.configuration.my_fancy_step.MyFancyStep'
+    );
   }
 
   render() {
@@ -89,8 +92,8 @@ const mapDispatchToProps = (dispatch) => ({
     );
     dispatch(sendButtonClickedEventRoutine(org, buttonEvent));
   },
-  getWorkConfiguration: (org, id) => {
-    const urlTemplate = '/api/0/organizations/{org}/work-configrations/';
+  getWorkConfiguration: (org, cls_full_name) => {
+    const urlTemplate = '/api/0/organizations/{org}/work-definition-details/{id}';
     const getWorkConfigurationRoutine = resourceActionCreators.acGet(
       WORK_CONFIGURATION,
       urlTemplate

--- a/src/sentry/static/sentry/app/views/exampleWorkbatch/index.jsx
+++ b/src/sentry/static/sentry/app/views/exampleWorkbatch/index.jsx
@@ -1,0 +1,30 @@
+import ClimsTypes from 'app/climsTypes';
+import React from 'react';
+import withOrganization from 'app/utils/withOrganization';
+import {connect} from 'react-redux';
+import {resourceActionCreators} from 'app/redux/actions/shared';
+import {getWorkBatchDetails} from 'app/redux/actions/workBatchDetails';
+import LoadingIndicator from 'app/components/loadingIndicator';
+
+class ExampleWorkbatchContainer extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+  }
+
+ExampleWorkbatchContainer.propTypes = {
+  ...ClimsTypes.List,
+  organization: ClimsTypes.Organization.isRequired,
+};
+
+const mapStateToProps = (state) => {
+};
+
+const mapDispatchToProps = (dispatch) => ({
+});
+
+export default withOrganization(
+  connect(mapStateToProps, mapDispatchToProps)(ExampleWorkbatchContainer)
+);

--- a/src/sentry/static/sentry/app/views/taskDefinitions/taskDefinitions.jsx
+++ b/src/sentry/static/sentry/app/views/taskDefinitions/taskDefinitions.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {t} from 'app/locale';
 import {Panel, PanelBody} from 'app/components/panels';
+import {browserHistory} from 'react-router';
 import ProcessListItem from 'app/views/taskDefinitions/processListItem';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -83,14 +84,21 @@ export class TaskDefinitions extends React.Component {
     return <LoadingIndicator />;
   }
 
+  redirectToExample() {
+    const redirect = `/lab/example-workbatch/`;
+    return void browserHistory.push(redirect);
+  }
+
   renderEmpty() {
     const message = t('Sorry, no tasks match your filters.');
-
     return (
       <div className="empty-stream" style={{border: 0}}>
         <p>
           <span className="icon icon-exclamation" /> {message}
         </p>
+        <button className="btn btn-sm btn-default" onClick={this.redirectToExample}>
+          {'Show example workbatch'}
+        </button>
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/index.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/index.jsx
@@ -1,0 +1,28 @@
+import ClimsTypes from 'app/climsTypes';
+import React from 'react';
+import withOrganization from 'app/utils/withOrganization';
+import {connect} from 'react-redux';
+import WorkbatchDetails from 'app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails';
+
+class WorkBatchDetailsWaitingToBeMergedContainer extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return <WorkbatchDetails>organization=this.props.organization</WorkbatchDetails>;
+  }
+}
+
+WorkBatchDetailsWaitingToBeMergedContainer.propTypes = {
+  ...ClimsTypes.List,
+  organization: ClimsTypes.Organization.isRequired,
+};
+
+const mapStateToProps = (state) => {};
+
+const mapDispatchToProps = (dispatch) => ({});
+
+export default withOrganization(
+  connect(mapStateToProps, mapDispatchToProps)(WorkBatchDetailsWaitingToBeMergedContainer)
+);

--- a/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
@@ -94,7 +94,7 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(sendButtonClickedEventRoutine(org, buttonEvent));
   },
   getWorkDefinition: (org, cls_full_name) => {
-    const urlTemplate = '/api/0/organizations/{org}/work-definition-details/{id}';
+    const urlTemplate = '/api/0/organizations/{org}/work-batch-definition-details/{id}';
     const getWorkDefinitionRoutine = resourceActionCreators.acGet(
       WORK_DEFINITION,
       urlTemplate

--- a/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
@@ -7,7 +7,7 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import moxios from 'moxios';
 import {WORK_DEFINITION, EVENTS} from 'app/redux/reducers/index';
 
-class ExampleWorkbatchContainer extends React.Component {
+class WorkbatchDetails extends React.Component {
   constructor(props) {
     super(props);
     this.props.getWorkDefinition(
@@ -17,6 +17,7 @@ class ExampleWorkbatchContainer extends React.Component {
   }
 
   render() {
+    //TODO: merge this with files in the workBatchDetails folder
     const buttonsFromConfig = [];
     let workDefinitionEntry = this.props.workDefinitionEntry;
     if (workDefinitionEntry == null) {
@@ -59,7 +60,7 @@ class ExampleWorkbatchContainer extends React.Component {
   }
 }
 
-ExampleWorkbatchContainer.propTypes = {
+WorkbatchDetails.propTypes = {
   ...ClimsTypes.List,
   organization: ClimsTypes.Organization.isRequired,
 };
@@ -113,5 +114,5 @@ const mapDispatchToProps = (dispatch) => ({
 });
 
 export default withOrganization(
-  connect(mapStateToProps, mapDispatchToProps)(ExampleWorkbatchContainer)
+  connect(mapStateToProps, mapDispatchToProps)(WorkbatchDetails)
 );

--- a/tests/js/spec/redux/actions/eventTriggers.spec.js
+++ b/tests/js/spec/redux/actions/eventTriggers.spec.js
@@ -1,0 +1,60 @@
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import moxios from 'moxios';
+import {resourceActionCreators} from 'app/redux/actions/shared';
+
+const EVENT = 'EVENT';
+
+describe('button event redux action', () => {
+  beforeEach(function () {
+    moxios.install();
+  });
+
+  afterEach(function () {
+    moxios.uninstall();
+  });
+
+  const middlewares = [thunk];
+  const mockStore = configureStore(middlewares);
+
+  describe('create event', () => {
+    it('should create an action to send post event', () => {
+      const store = mockStore({});
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          headers: [],
+        });
+      });
+
+      const buttonClickedEvent = {
+        event: 'mybutton_clicked',
+        workbatchId: 4,
+      };
+      const expectedActions = [
+        {
+          type: 'CREATE_EVENT_REQUEST',
+          entry: buttonClickedEvent,
+        },
+        {
+          type: 'CREATE_EVENT_SUCCESS',
+          entry: buttonClickedEvent,
+        },
+      ];
+      const org = {
+        slug: 'lab',
+      };
+      const urlTemplate = '/api/0/organizations/{org}/events/';
+      const startButtonClickedEvent = resourceActionCreators.acCreate(EVENT, urlTemplate);
+      const action = startButtonClickedEvent(org, buttonClickedEvent);
+
+      return store.dispatch(action).then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+        expect(moxios.requests.count()).toEqual(1);
+        const request = moxios.requests.mostRecent();
+        expect(request.url).toBe('/api/0/organizations/lab/events/');
+      });
+    });
+  });
+});

--- a/tests/js/spec/redux/actions/shared.spec.js
+++ b/tests/js/spec/redux/actions/shared.spec.js
@@ -172,7 +172,7 @@ describe('shared async actions', () => {
 
   it('can get a single entry', () => {
     const store = mockStore({});
-    const url = '/url?search=search&cursor=cursor';
+    const urlTemplate = '/api/0/organizations/{org}/resource-details/{id}';
 
     // NOTE: Using this instead of stubRequest as it's easier to debug
     moxios.wait(() => {
@@ -186,11 +186,15 @@ describe('shared async actions', () => {
       });
     });
 
-    const actionCreator = resourceActionCreators.acGet(RESOURCE_NAME, url);
-    const action = actionCreator();
+    const actionCreator = resourceActionCreators.acGet(RESOURCE_NAME, urlTemplate);
+    const org = {
+      slug: 'lab',
+    };
+    const action = actionCreator(org, 2);
     const expectedActions = [
       {
         type: 'GET_RESOURCE_NAME_REQUEST',
+        id: 2,
       },
       {
         type: 'GET_RESOURCE_NAME_SUCCESS',
@@ -201,6 +205,8 @@ describe('shared async actions', () => {
     return store.dispatch(action).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
       expect(moxios.requests.count()).toEqual(1);
+      const request = moxios.requests.mostRecent();
+      expect(request.url).toBe('/api/0/organizations/lab/resource-details/2/');
     });
   });
   it('can send POST event', () => {

--- a/tests/js/spec/redux/reducers/workConfiguration.spec.js
+++ b/tests/js/spec/redux/reducers/workConfiguration.spec.js
@@ -1,0 +1,33 @@
+import {Set} from 'immutable';
+import {resource} from 'app/redux/reducers/shared';
+import {makeResourceActions} from 'app/redux/actions/shared';
+
+const WORK_CONFIGURATION = 'WORK_CONFIGURATION';
+
+const initialState = {
+  ...resource.initialState,
+};
+
+const actions = makeResourceActions(WORK_CONFIGURATION, '/api/0/work-configurations/');
+const reducer = resource.createReducer(WORK_CONFIGURATION, initialState);
+
+describe('work configuration', () => {
+  it('has expected state when getting a successful single entry response', () => {});
+  const requestState = reducer(initialState, actions.getRequest());
+  // We must get an item with an id back:
+  const fetchedItem = {
+    id: 1,
+    buttons: [
+      {
+        name: 'button1',
+        caption: 'button 1',
+      },
+    ],
+  };
+  const successState = reducer(requestState, actions.getSuccess(fetchedItem));
+  expect(successState).toEqual({
+    ...initialState,
+    detailsId: 1,
+    byIds: {1: fetchedItem},
+  });
+});


### PR DESCRIPTION
Purpose:
Show buttons in a workbatch view according to a configuration provided by the api. 

Scope:
This is an implementation in the UI only. The corresponding endpoints /work-configurations and /events is not yet implemented in the backend. Furthermore, since a workbatch page is not yet in place, I started with one here and called it "example workbatch". This page only handles buttons, nothing else. 

Implementation:
I use the general actions creators in shared.js to create actions for the button clicked events as well as fetching a work configuration. 

Note:
I left some method name changes in workBatchDetials from previous changes. Most of them were changed back. Please have a look if these method names were the intended. They were inconsistent when I found them ("get" in the beginning or in the middle of the method name). 