### PR TITLE
clims-463, Merge to workbatchbase with WorkBatchDefinitionBase

### DIFF
--- a/src/clims/configuration/work_batch_definition.py
+++ b/src/clims/configuration/work_batch_definition.py
@@ -1,60 +1,6 @@
 from __future__ import absolute_import, print_function
-from six import iteritems
-from collections import namedtuple
-from clims.configuration.hooks import HOOK_TAG, HOOK_TYPE
 from clims.services.workbatch import WorkBatchBase
 
 
 class WorkBatchDefinitionBase(WorkBatchBase):
-    """
-    In plugin configuration, an event triggered at a button click
-    is created as this:
-
-    from configuration.work_batch_defintion import WorkBatchDefinitionBase
-    from configuration.hooks import button
-    from clims.services import TextField
-
-    class MyFancyStep(WorkBatchDefinitionBase):
-        todays_flavour = TextField()
-
-        @button('My submit button')
-        def on_button_click1xx():
-            from my_plugin_code.fancy_script import Fancy
-            myscript = Fancy()
-            myscript.run()
-
-    This will happen:
-    1. User enters a step in UI corresponding to MyFancyStep
-        > A button will appear with text "My submit button"
-    2. User press button "My submit button"
-        > The method "on_button_click1xx" is triggered
-
-    """
-
-    @classmethod
-    def cls_full_name(cls):
-        # Corresponds to 'full_name' in serializer
-        return cls.type_full_name_cls()
-
-    @classmethod
-    def buttons(cls):
-        buttons = list()
-        for _, v in iteritems(cls.__dict__):
-            if callable(v) and hasattr(v, HOOK_TAG) and \
-                    hasattr(v, HOOK_TYPE) and getattr(v, HOOK_TYPE) == 'button':
-                b = Button(name=v.__name__, caption=getattr(v, HOOK_TAG))
-                buttons.append(b)
-        return buttons
-
-    def trigger(self, event):
-        class_dict = dict(self.__class__.__dict__)
-        for k, v in iteritems(class_dict):
-            if self._matches_event(k, v, event):
-                v(self)
-
-    def _matches_event(self, attribute_key, attribute_value, event):
-        return callable(attribute_value) and attribute_key == event
-
-
-class Button(namedtuple("Button", ['name', 'caption'])):
     pass

--- a/src/clims/plugins/demo/dnaseq/configuration/my_fancy_step.py
+++ b/src/clims/plugins/demo/dnaseq/configuration/my_fancy_step.py
@@ -1,8 +1,8 @@
-from clims.configuration.work_batch_definition import WorkBatchDefinitionBase
+from clims.services.workbatch import WorkBatchBase
 from clims.configuration.hooks import button
 
 
-class MyFancyStep(WorkBatchDefinitionBase):
+class MyFancyStep(WorkBatchBase):
     name = 'My fancy step'
 
     @button('My submit button')

--- a/src/clims/plugins/demo/dnaseq/models.py
+++ b/src/clims/plugins/demo/dnaseq/models.py
@@ -3,7 +3,7 @@ from clims.services.substance import SubstanceBase
 from clims.services.project import ProjectBase
 from clims.services.extensible import FloatField, TextField
 from clims.services.container import PlateBase
-from clims.configuration.work_batch_definition import WorkBatchDefinitionBase
+from clims.services.workbatch import WorkBatchBase
 from clims.configuration.hooks import button
 
 
@@ -32,11 +32,11 @@ class PandorasBox(PlateBase):
 
 
 # TODO: attach files
-class ExampleWorkBatch(WorkBatchDefinitionBase):
+class ExampleWorkBatch(WorkBatchBase):
     pass
 
 
-class WorkInProgressWorkBatch(WorkBatchDefinitionBase):
+class WorkInProgressWorkBatch(WorkBatchBase):
     @button("Start some work")
     def start_work(self):
         print("start work button clicked")

--- a/src/clims/services/workbatch.py
+++ b/src/clims/services/workbatch.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+from six import iteritems
+from collections import namedtuple
 from sentry.models.file import File
 from clims.services.file_handling.file_service import FILENAME_RE, FileNameValidationError
 from clims.services.extensible import ExtensibleBase
@@ -6,6 +8,7 @@ from clims.services.base_extensible_service import BaseExtensibleService
 from clims.services.base_extensible_service import BaseQueryBuilder
 from clims.models.workbatchfile import WorkBatchFile as WorkBatchFileModel
 from clims.models.work_batch import WorkBatch, WorkBatchVersion
+from clims.configuration.hooks import HOOK_TAG, HOOK_TYPE
 
 
 class WorkbatchService(BaseExtensibleService):
@@ -14,8 +17,56 @@ class WorkbatchService(BaseExtensibleService):
 
 
 class WorkBatchBase(ExtensibleBase):
+    """
+    In plugin configuration, an event triggered at a button click
+    is created as this:
+
+    from configuration.work_batch_defintion import WorkBatchDefinitionBase
+    from configuration.hooks import button
+    from clims.services import TextField
+
+    class MyFancyStep(WorkBatchDefinitionBase):
+        todays_flavour = TextField()
+
+        @button('My submit button')
+        def on_button_click1xx():
+            from my_plugin_code.fancy_script import Fancy
+            myscript = Fancy()
+            myscript.run()
+
+    This will happen:
+    1. User enters a step in UI corresponding to MyFancyStep
+        > A button will appear with text "My submit button"
+    2. User press button "My submit button"
+        > The method "on_button_click1xx" is triggered
+
+    """
     WrappedArchetype = WorkBatch
     WrappedVersion = WorkBatchVersion
+
+    @classmethod
+    def cls_full_name(cls):
+        # Corresponds to 'full_name' in serializer
+        return cls.type_full_name_cls()
+
+    @classmethod
+    def buttons(cls):
+        buttons = list()
+        for _, v in iteritems(cls.__dict__):
+            if callable(v) and hasattr(v, HOOK_TAG) and \
+                    hasattr(v, HOOK_TYPE) and getattr(v, HOOK_TYPE) == 'button':
+                b = Button(name=v.__name__, caption=getattr(v, HOOK_TAG))
+                buttons.append(b)
+        return buttons
+
+    def trigger(self, event):
+        class_dict = dict(self.__class__.__dict__)
+        for k, v in iteritems(class_dict):
+            if self._matches_event(k, v, event):
+                v(self)
+
+    def _matches_event(self, attribute_key, attribute_value, event):
+        return callable(attribute_value) and attribute_key == event
 
     def add_file(self, file_stream, name, file_handle):
         if FILENAME_RE.search(name):
@@ -56,6 +107,10 @@ class WorkBatchBase(ExtensibleBase):
     @status.setter
     def status(self, value):
         self._archetype.status = value
+
+
+class Button(namedtuple("Button", ['name', 'caption'])):
+    pass
 
 
 class WorkBatchFile(object):

--- a/tests/clims/api/endpoints/test_event.py
+++ b/tests/clims/api/endpoints/test_event.py
@@ -4,7 +4,7 @@ import json
 from rest_framework import status
 from sentry.testutils import APITestCase
 from django.core.urlresolvers import reverse
-from clims.configuration.work_batch_definition import WorkBatchDefinitionBase
+from clims.services.workbatch import WorkBatchBase
 from clims.configuration.hooks import button
 
 
@@ -34,7 +34,7 @@ class TestEvent(APITestCase):
         assert getattr(MyFancyStep, 'was_called') is True
 
 
-class MyFancyStep(WorkBatchDefinitionBase):
+class MyFancyStep(WorkBatchBase):
     name = 'My fancy step'
 
     @button('My submit button')

--- a/tests/clims/api/endpoints/test_work_batch_details_definition.py
+++ b/tests/clims/api/endpoints/test_work_batch_details_definition.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import pytest
 from sentry.testutils import APITestCase
 from django.core.urlresolvers import reverse
-from clims.configuration.work_batch_definition import WorkBatchDefinitionBase
+from clims.services.workbatch import WorkBatchBase
 from clims.configuration.hooks import button
 from clims.api.serializers.models.work_batch_details_definition import WorkBatchDetailsDefinitionSerializer
 
@@ -32,7 +32,7 @@ class TestWorkDefinition(APITestCase):
             [{"caption": "My submit button", "event": "on_button_click1"}]
 
 
-class MyFancyStep(WorkBatchDefinitionBase):
+class MyFancyStep(WorkBatchBase):
     name = 'My fancy step'
 
     @button('My submit button')

--- a/tests/clims/api/serializers/models/test_work_batch.py
+++ b/tests/clims/api/serializers/models/test_work_batch.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from sentry.testutils import TestCase
 
 from clims.api.serializers.models.work_batch import WorkBatchSerializer
-from clims.configuration.work_batch_definition import WorkBatchDefinitionBase
+from clims.services.workbatch import WorkBatchBase
 
 
 class WorkBatchSerializerTest(TestCase):
@@ -19,5 +19,5 @@ class WorkBatchSerializerTest(TestCase):
         assert result.get('cls_full_name') == 'serializers.models.test_work_batch.MyWorkbatchImplementation'
 
 
-class MyWorkbatchImplementation(WorkBatchDefinitionBase):
+class MyWorkbatchImplementation(WorkBatchBase):
     pass

--- a/tests/clims/api/serializers/models/test_work_batch_details_definition.py
+++ b/tests/clims/api/serializers/models/test_work_batch_details_definition.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from sentry.testutils import TestCase
 
 from clims.api.serializers.models.work_batch_details_definition import WorkBatchDetailsDefinitionSerializer
-from clims.configuration.work_batch_definition import WorkBatchDefinitionBase
+from clims.services.workbatch import WorkBatchBase
 from clims.configuration.hooks import button
 
 
@@ -21,9 +21,9 @@ class WorkBatchDetailsDefintionSerializerTest(TestCase):
         assert result.get('buttons') == [{'caption': 'My submit button', 'event': 'on_button_click1'}]
 
 
-class MyFancyStep(WorkBatchDefinitionBase):
+class MyFancyStep(WorkBatchBase):
     name = 'My fancy step'
 
     @button('My submit button')
-    def on_button_click1(self, workbatch):
+    def on_button_click1(self):
         setattr(MyFancyStep, 'was_called', True)

--- a/tests/clims/models/test_work_definition.py
+++ b/tests/clims/models/test_work_definition.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 import pytest
 from sentry.testutils import TestCase
-from clims.configuration.work_batch_definition import WorkBatchDefinitionBase, Button
+from clims.services.workbatch import WorkBatchBase
+from clims.services.workbatch import Button
 from clims.configuration.hooks import button
 from clims.services.extensible import FloatField
 
@@ -25,7 +26,7 @@ class TestWorkDefinition(TestCase):
         assert buttons[0] == Button(name='on_button_click1', caption='My submit button')
 
 
-class MyFancyWork(WorkBatchDefinitionBase):
+class MyFancyWork(WorkBatchBase):
     name = 'My fancy step'
     concentration = FloatField(display_name='Concentration (ng/ul)')
 


### PR DESCRIPTION
Purpose:
I find it confusing to have these classes separated. In particular when instantiating new work batch implementations like

ExampleWorkBatch(WorkBatchBase)

vs. 

ExampleWorkBatch(WorkBatchDefinitionBase)