### PR TITLE
clims-466, Implement update/PUT in shared reduxer

### DIFF
--- a/src/sentry/static/sentry/app/redux/actions/shared.js
+++ b/src/sentry/static/sentry/app/redux/actions/shared.js
@@ -47,9 +47,10 @@ const acGetList = (resource, urlTemplate) => {
     return axios
       .get(url, config)
       .then((res) => dispatch(acGetListSuccess(resource)(res.data, res.headers.link)))
-      .catch((err) =>
-        dispatch(acGetListFailure(resource)(err.statusCode, err.statusText))
-      );
+      .catch((response) => {
+        const message = getErrorMessage(response.request);
+        dispatch(acGetListFailure(resource)(response.request.status, message));
+      });
   };
 };
 
@@ -75,7 +76,6 @@ const acCreate = (resource, urlTemplate) => {
 
     const url = urlTemplate.replace('{org}', org.slug);
     // use client that sentry is using
-    //
     const api = new Client(); // TODO: use axios (must send same headers as Client does).
     api.request(url, {
       method: 'POST',
@@ -84,17 +84,23 @@ const acCreate = (resource, urlTemplate) => {
         dispatch(acCreateSuccess(resource)(data));
       },
       error: (err) => {
-        dispatch(acCreateFailure(resource)(err.statusCode, err.statusText));
+        const message = getErrorMessage(err);
+        dispatch(acCreateFailure(resource)(err.status, message));
       },
     });
     // return axios
     //   .post(url, data)
     //   .then(() => dispatch(acCreateSuccess(resource)(data)))
-    //   .catch((err) =>
-    //     dispatch(acCreateFailure(resource)(err.statusCode, err.statusText))
-    //   );
+    //   .catch((response) => {
+    //     const message = getErrorMessage(response.request);
+    //     dispatch(acCreateFailure(resource)(response.request.status, message));
+    //   });
   };
 };
+
+function getErrorMessage(err) {
+  return `(${err.statusText}) ${err.responseText}`;
+}
 
 ////////////////////////
 // Update single resource
@@ -155,7 +161,10 @@ const acGet = (resource, urlTemplate) => {
     return axios
       .get(url)
       .then((res) => dispatch(acGetSuccess(resource)(res.data)))
-      .catch((err) => dispatch(acGetFailure(resource)(err)));
+      .catch((response) => {
+        const message = getErrorMessage(response.request);
+        dispatch(acGetFailure(resource)(response.request.status, message));
+      });
   };
 };
 

--- a/src/sentry/static/sentry/app/redux/actions/shared.js
+++ b/src/sentry/static/sentry/app/redux/actions/shared.js
@@ -119,8 +119,6 @@ const acUpdate = (resource, urlTemplate) => {
         dispatch(acUpdateSuccess(resource)(data));
       },
       error: (err) => {
-        console.log('ac udpate');
-        console.log(err);
         const message = getErrorMessage(err);
         dispatch(acUpdateFailure(resource)(err.status, message));
       },

--- a/src/sentry/static/sentry/app/redux/actions/shared.js
+++ b/src/sentry/static/sentry/app/redux/actions/shared.js
@@ -88,6 +88,7 @@ const acCreate = (resource, urlTemplate) => {
         dispatch(acCreateFailure(resource)(err.status, message));
       },
     });
+    // TODO: uncomment this when clims-465 is completed
     // return axios
     //   .post(url, data)
     //   .then(() => dispatch(acCreateSuccess(resource)(data)))
@@ -123,6 +124,7 @@ const acUpdate = (resource, urlTemplate) => {
         dispatch(acUpdateFailure(resource)(err.status, message));
       },
     });
+    // TODO: uncomment this when clims-465 is completed
     // return axios
     //   .put(url, data)
     //   .then(() => dispatch(acUpdateSuccess(resource)(data)))

--- a/src/sentry/static/sentry/app/redux/reducers/shared.js
+++ b/src/sentry/static/sentry/app/redux/reducers/shared.js
@@ -122,13 +122,21 @@ export function updateEntryRequest(state, action) {
   };
 }
 
-export function updateEntrySucess(state, action) {
+export function updateEntrySuccess(state, action) {
   const byIds = {};
   byIds[action.entry.id] = action.entry;
   return {
     ...state,
     updating: false,
     byIds: merge({}, state.byIds, byIds),
+  };
+}
+
+export function updateEntryFailure(state, action) {
+  return {
+    ...state,
+    updating: false,
+    errorMessage: action.message,
   };
 }
 
@@ -189,7 +197,9 @@ const createResourceReducer = (resource, initialState) => (
     case `UPDATE_${resource}_REQUEST`:
       return updateEntryRequest(state, action);
     case `UPDATE_${resource}_SUCCESS`:
-      return updateEntrySucess(state, action);
+      return updateEntrySuccess(state, action);
+    case `UPDATE_${resource}_FAILURE`:
+      return updateEntryFailure(state, action);
 
     default:
       return state;
@@ -240,7 +250,8 @@ export const entry = {
   getEntrySuccess,
   getEntryFailure,
   updateEntryRequest,
-  updateEntrySucess,
+  updateEntrySuccess,
+  updateEntryFailure,
 };
 
 // A resource follows both the list and entry protocols

--- a/src/sentry/static/sentry/app/redux/reducers/shared.js
+++ b/src/sentry/static/sentry/app/redux/reducers/shared.js
@@ -206,6 +206,7 @@ export const entry = {
   // Required state for following an entry protocol
   initialState: {
     loadingDetails: false,
+    updating: false,
     detailsId: null,
   },
 

--- a/src/sentry/static/sentry/app/redux/reducers/shared.js
+++ b/src/sentry/static/sentry/app/redux/reducers/shared.js
@@ -114,6 +114,24 @@ export function createEntryFailure(state, action) {
   };
 }
 
+export function updateEntryRequest(state, action) {
+  return {
+    ...state,
+    updating: true,
+    errorMessage: null,
+  };
+}
+
+export function updateEntrySucess(state, action) {
+  const byIds = {};
+  byIds[action.entry.id] = action.entry;
+  return {
+    ...state,
+    updating: false,
+    byIds: merge({}, state.byIds, byIds),
+  };
+}
+
 export function getEntryRequest(state, action) {
   return {
     ...state,
@@ -168,6 +186,10 @@ const createResourceReducer = (resource, initialState) => (
       return createEntrySuccess(state, action);
     case `CREATE_${resource}_FAILURE`:
       return createEntryFailure(state, action);
+    case `UPDATE_${resource}_REQUEST`:
+      return updateEntryRequest(state, action);
+    case `UPDATE_${resource}_SUCCESS`:
+      return updateEntrySucess(state, action);
 
     default:
       return state;
@@ -217,6 +239,8 @@ export const entry = {
   getEntryRequest,
   getEntrySuccess,
   getEntryFailure,
+  updateEntryRequest,
+  updateEntrySucess,
 };
 
 // A resource follows both the list and entry protocols

--- a/tests/js/spec/redux/actions/shared.spec.js
+++ b/tests/js/spec/redux/actions/shared.spec.js
@@ -280,4 +280,41 @@ describe('shared async actions', () => {
       expect(request.url).toBe('/api/0/organizations/lab/resource-name/');
     });
   });
+  it.skip('can handle PUT event', () => {
+    const store = mockStore({});
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 200,
+      });
+    });
+
+    const newState = {
+      id: 5,
+      someEntry: 'new value',
+    };
+    const expectedActions = [
+      {
+        type: 'UPDATE_RESOURCE_NAME_REQUEST',
+        entry: newState,
+      },
+      {
+        type: 'UPDATE_RESOURCE_NAME_SUCCESS',
+        entry: newState,
+      },
+    ];
+    const org = {
+      slug: 'lab',
+    };
+    const urlTemplate = '/api/0/organizations/{org}/resource-name/{id}';
+    const acUpdateRoutine = resourceActionCreators.acUpdate(RESOURCE_NAME, urlTemplate);
+    const action = acUpdateRoutine(org, newState);
+
+    return store.dispatch(action).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+      expect(moxios.requests.count()).toEqual(1);
+      const request = moxios.requests.mostRecent();
+      expect(request.url).toBe('/api/0/organizations/lab/resource-name/5/');
+    });
+  });
 });

--- a/tests/js/spec/redux/actions/shared.spec.js
+++ b/tests/js/spec/redux/actions/shared.spec.js
@@ -144,10 +144,16 @@ describe('shared async actions', () => {
     // NOTE: Using this instead of stubRequest as it's easier to debug
     moxios.wait(() => {
       const request = moxios.requests.mostRecent();
-      request.respondWith({
+      const errResp = {
         status: 400,
+        request: {
+          status: 400,
+          statusText: 'a bad request',
+          responseText: 'response text',
+        },
         headers: [],
-      });
+      };
+      request.reject(errResp);
     });
 
     const actionCreator = resourceActionCreators.acGetList(RESOURCE_NAME, '/url');
@@ -161,6 +167,8 @@ describe('shared async actions', () => {
       },
       {
         type: 'GET_RESOURCE_NAME_LIST_FAILURE',
+        statusCode: 400,
+        message: '(a bad request) response text',
       },
     ];
 

--- a/tests/js/spec/redux/reducers/shared.spec.js
+++ b/tests/js/spec/redux/reducers/shared.spec.js
@@ -186,7 +186,7 @@ describe('shared resource reducer', () => {
     expect(requestedState).toEqual(expectedState);
   });
 
-  it('has expected state when a single entry update has been succeeded', () => {
+  it('has expected state when a single entry update has succeeded', () => {
     const originalState = {
       ...initialState,
       detailsId: 5,
@@ -215,6 +215,35 @@ describe('shared resource reducer', () => {
     };
 
     expect(successState).toEqual(expectedState);
+  });
+
+  it('has expected state when a single entry update has failed', () => {
+    const originalState = {
+      ...initialState,
+      detailsId: 5,
+      updating: true,
+      byIds: {
+        5: {
+          id: 5,
+          name: 'orig-name',
+        },
+      },
+    };
+    const err = {
+      statusCode: 1,
+      message: 'oops',
+    };
+    const failedState = reducer(
+      originalState,
+      actions.updateFailure(err.statusCode, err.message)
+    );
+    const expectedState = {
+      ...originalState,
+      updating: false,
+      errorMessage: 'oops',
+    };
+
+    expect(failedState).toEqual(expectedState);
   });
 
   it('has expected state after requesting a single entry', () => {

--- a/tests/js/spec/redux/reducers/shared.spec.js
+++ b/tests/js/spec/redux/reducers/shared.spec.js
@@ -81,35 +81,6 @@ describe('shared resource reducer', () => {
     });
   });
 
-  it('has expected state when getting a failed response', () => {
-    const originalState = {...initialState};
-    const requestedState = reducer(
-      originalState,
-      actions.getListRequest('search', 'groupby', 'cursor')
-    );
-    const failedState = reducer(
-      requestedState,
-      actions.getListFailure(500, 'some error')
-    );
-    expect(failedState).toEqual({
-      loadingDetails: false,
-      detailsId: null,
-      loading: false,
-      updating: false,
-      errorMessage: 'some error',
-      byIds: {},
-      listViewState: {
-        allVisibleSelected: false,
-        groupBy: 'groupby',
-        search: 'search',
-        visibleIds: [],
-        selectedIds: new Set(),
-        pagination: {pageLinks: null, cursor: 'cursor'},
-      },
-      creating: false,
-    });
-  });
-
   it('has expected state when selecting/deselecting a page', () => {
     const successState = createGetListSuccessState();
     const selectedPageState = reducer(successState, actions.selectPage(true));

--- a/tests/js/spec/redux/reducers/shared.spec.js
+++ b/tests/js/spec/redux/reducers/shared.spec.js
@@ -41,6 +41,7 @@ describe('shared resource reducer', () => {
       loadingDetails: false,
       detailsId: null,
       loading: true,
+      updating: false,
       errorMessage: null,
       byIds: {},
       listViewState: {
@@ -61,6 +62,7 @@ describe('shared resource reducer', () => {
       loadingDetails: false,
       detailsId: null,
       loading: false,
+      updating: false,
       errorMessage: null,
       byIds: {'1': {id: '1', name: 'entry1'}, '2': {id: '2', name: 'entry2'}},
       listViewState: {
@@ -89,6 +91,7 @@ describe('shared resource reducer', () => {
       loadingDetails: false,
       detailsId: null,
       loading: false,
+      updating: false,
       errorMessage: 'some error',
       byIds: {},
       listViewState: {
@@ -218,6 +221,7 @@ describe('shared resource reducer', () => {
       loadingDetails: false,
       detailsId: null,
       loading: false,
+      updating: false,
       errorMessage: 'some error',
       byIds: {},
       listViewState: {

--- a/tests/js/spec/redux/reducers/shared.spec.js
+++ b/tests/js/spec/redux/reducers/shared.spec.js
@@ -10,7 +10,11 @@ const initialState = {
 };
 
 const reducer = resource.createReducer(RESOURCE_NAME, initialState);
-const actions = makeResourceActions(RESOURCE_NAME, '/api/0/some-resource/');
+const actions = makeResourceActions(
+  RESOURCE_NAME,
+  '/api/0/some-resource/',
+  '/api/0/some-resource/5/'
+);
 
 function createGetListSuccessState() {
   const originalState = {...initialState};
@@ -183,6 +187,63 @@ describe('shared resource reducer', () => {
         '3': newItem,
       },
     });
+  });
+
+  it('has expected state when a single entry update has been requested', () => {
+    const originalState = {
+      ...initialState,
+      detailsId: 5,
+      errorMessage: 'oops',
+      byIds: {
+        5: {
+          id: 5,
+          name: 'orig-name',
+        },
+      },
+    };
+    const entry = {
+      id: 5,
+      name: 'new-name',
+    };
+    const requestedState = reducer(originalState, actions.updateRequest(entry));
+    const expectedState = {
+      ...originalState,
+      updating: true,
+      errorMessage: null,
+    };
+
+    expect(requestedState).toEqual(expectedState);
+  });
+
+  it('has expected state when a single entry update has been succeeded', () => {
+    const originalState = {
+      ...initialState,
+      detailsId: 5,
+      updating: true,
+      byIds: {
+        5: {
+          id: 5,
+          name: 'orig-name',
+        },
+      },
+    };
+    const entry = {
+      id: 5,
+      name: 'new-name',
+    };
+    const successState = reducer(originalState, actions.updateSuccess(entry));
+    const expectedState = {
+      ...originalState,
+      updating: false,
+      byIds: {
+        5: {
+          id: 5,
+          name: 'new-name',
+        },
+      },
+    };
+
+    expect(successState).toEqual(expectedState);
   });
 
   it('has expected state after requesting a single entry', () => {

--- a/tests/js/spec/redux/reducers/taskDefinition.spec.js
+++ b/tests/js/spec/redux/reducers/taskDefinition.spec.js
@@ -10,6 +10,7 @@ describe('taskDefinition reducer, list protocol', () => {
     );
     const expected = {
       loading: true,
+      updating: false,
       errorMessage: null,
       byIds: {},
       listViewState: {
@@ -43,6 +44,7 @@ describe('taskDefinition reducer, list protocol', () => {
 
     const expected = {
       loading: false,
+      updating: false,
       errorMessage: null,
       byIds: {
         1: entries[0],


### PR DESCRIPTION
Purpose:
Since the update/PUT entry was not yet implemented in the shared action reducers, I implemented it here. In addition, I also fixed so that detailed api error messages are showed in the UI console for the shared action/reducers. 

Method for testing:
For axios calls (not sentry Client calls), I changed the failure actions to receive data from (response.request), instead of just (err). The latter one just didn't return anything. This was discovered by injecting errors in the code, so that the endpoint would reply with an error, trigger that error from the UI, and then inspect the response. 