### PR TITLE
clims-442, Update workbatch properties from UI

### DIFF
--- a/src/clims/api/endpoints/work_batch_details.py
+++ b/src/clims/api/endpoints/work_batch_details.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from rest_framework.response import Response
+from rest_framework import status
 from clims.api.bases.work_batch import WorkBatchBaseEndpoint
 from clims.api.serializers.models.work_batch_details import WorkBatchDetailsSerializer
 
@@ -9,3 +10,11 @@ class WorkBatchDetailsEndpoint(WorkBatchBaseEndpoint):
     def get(self, request, organization_slug, work_batch_id):
         workbatch = self.app.workbatches.get(id=work_batch_id)
         return Response(WorkBatchDetailsSerializer(workbatch).data, status=200)
+
+    def put(self, request, organization_slug, work_batch_id):
+        workbatch = self.app.workbatches.get(id=work_batch_id)
+        serializer = WorkBatchDetailsSerializer(workbatch, data=request.data)
+        if not serializer.is_valid():
+            return self.respond(serializer.errors, status=400)
+        serializer.save()
+        return Response({}, status=status.HTTP_200_OK)

--- a/src/clims/api/serializers/models/extensible_property.py
+++ b/src/clims/api/serializers/models/extensible_property.py
@@ -5,11 +5,6 @@ from rest_framework import serializers
 
 
 class ExtensiblePropertySerializer(serializers.Serializer):
-    id = serializers.CharField(read_only=True)
-    version = serializers.IntegerField(read_only=True)
     name = serializers.CharField(read_only=True)
     display_name = serializers.CharField(read_only=True)
-    value = serializers.SerializerMethodField(method_name="get_value_with_correct_type")
-
-    def get_value_with_correct_type(self, obj):
-        return obj.value
+    value = serializers.CharField()

--- a/src/clims/api/serializers/models/extensible_property.py
+++ b/src/clims/api/serializers/models/extensible_property.py
@@ -6,5 +6,4 @@ from rest_framework import serializers
 
 class ExtensiblePropertySerializer(serializers.Serializer):
     name = serializers.CharField(read_only=True)
-    display_name = serializers.CharField(read_only=True)
     value = serializers.CharField()

--- a/src/clims/api/serializers/models/work_batch_details.py
+++ b/src/clims/api/serializers/models/work_batch_details.py
@@ -7,4 +7,12 @@ from clims.api.serializers.models.extensible_property import ExtensiblePropertyS
 class WorkBatchDetailsSerializer(serializers.Serializer):
     id = serializers.IntegerField(read_only=True)
     name = serializers.CharField(read_only=True)
-    properties = DictField(child=ExtensiblePropertySerializer(read_only=True))
+    properties = DictField(child=ExtensiblePropertySerializer(), allow_null=True)
+
+    def update(self, instance, validated_data):
+        if validated_data['properties'] is None:
+            return instance
+        for p in validated_data['properties']:
+            setattr(instance, p, validated_data['properties'][p]['value'])
+        instance.save()
+        return instance

--- a/src/clims/plugins/demo/dnaseq/handlers/create_example_data.py
+++ b/src/clims/plugins/demo/dnaseq/handlers/create_example_data.py
@@ -77,7 +77,7 @@ class DemoCreateExampleDataHandler(CreateExampleDataHandler):
         # Create workbatch to be used at wip workbatch details page. The
         # name of the workbatch has to be known here.
         workbatch = ExampleWorkBatch(name='wip-workbatch', status=1)
-        workbatch.kit_type = "X"
+        # workbatch.kit_type = "X"
         workbatch.save()
         logger.info("Created wip workbatch")
 

--- a/src/clims/plugins/demo/dnaseq/handlers/create_example_data.py
+++ b/src/clims/plugins/demo/dnaseq/handlers/create_example_data.py
@@ -77,7 +77,7 @@ class DemoCreateExampleDataHandler(CreateExampleDataHandler):
         # Create workbatch to be used at wip workbatch details page. The
         # name of the workbatch has to be known here.
         workbatch = ExampleWorkBatch(name='wip-workbatch', status=1)
-        # workbatch.kit_type = "X"
+        workbatch.kit_type = "X"
         workbatch.save()
         logger.info("Created wip workbatch")
 

--- a/src/clims/plugins/demo/dnaseq/handlers/create_example_data.py
+++ b/src/clims/plugins/demo/dnaseq/handlers/create_example_data.py
@@ -77,6 +77,7 @@ class DemoCreateExampleDataHandler(CreateExampleDataHandler):
         # Create workbatch to be used at wip workbatch details page. The
         # name of the workbatch has to be known here.
         workbatch = ExampleWorkBatch(name='wip-workbatch', status=1)
+        # This to test UI that it handles both initialized as well as not initialized fields
         workbatch.kit_type = "X"
         workbatch.save()
         logger.info("Created wip workbatch")

--- a/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
@@ -13,6 +13,9 @@ import {EVENTS} from 'app/redux/reducers/event';
 class WorkbatchDetails extends React.Component {
   constructor(props) {
     super(props);
+  }
+
+  componentDidMount() {
     const getWipWorkbatch = this.props.getWipWorkbatch;
     const org = this.props.organization;
     getWipWorkbatch(org)

--- a/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
@@ -18,6 +18,7 @@ class WorkbatchDetails extends React.Component {
     this.handleChange = this.handleChange.bind(this);
     this.sendButtonClickedEvent = this.sendButtonClickedEvent.bind(this);
     this.initCurrentFieldValues = this.initCurrentFieldValues.bind(this);
+    this.fetchDefinitionsFromProps = this.fetchDefinitionsFromProps.bind(this);
     this.setFetched = this.setFetched.bind(this);
     const getWipWorkbatch = this.props.getWipWorkbatch;
     const org = this.props.organization;
@@ -25,6 +26,7 @@ class WorkbatchDetails extends React.Component {
       .then(this.fetchStaticContentsFromWip)
       .then(this.fetchDetailedContentFromWip)
       .then(this.initCurrentFieldValues)
+      .then(this.fetchDefinitionsFromProps)
       .then(this.setFetched);
   }
 
@@ -63,7 +65,14 @@ class WorkbatchDetails extends React.Component {
     if (!fields || !buttons || !id) {
       return;
     }
-    return workDefinition;
+    return new Promise((resolve) => {
+      this.setState((prevState) => {
+        return {
+          ...prevState,
+          workDefinition,
+        };
+      }, resolve);
+    });
   }
 
   sendButtonClickedEvent(buttonEvent) {
@@ -79,14 +88,13 @@ class WorkbatchDetails extends React.Component {
     ) {
       return <LoadingIndicator />;
     }
-    let workDefinition = this.fetchDefinitionsFromProps();
-    if (!workDefinition) {
+    if (!this.state.workDefinition) {
       return <LoadingIndicator />;
     }
     let {detailsId: workbatchId} = this.props.workBatchDetailsEntry;
     return (
       <DetailsForm
-        workDefinition={workDefinition}
+        workDefinition={this.state.workDefinition}
         sendButtonClickedEvent={this.sendButtonClickedEvent}
         handleChange={this.handleChange}
         currentFieldValues={this.state.currentFieldValues}

--- a/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
@@ -13,13 +13,6 @@ import {EVENTS} from 'app/redux/reducers/event';
 class WorkbatchDetails extends React.Component {
   constructor(props) {
     super(props);
-    this.fetchStaticContentsFromWip = this.fetchStaticContentsFromWip.bind(this);
-    this.fetchDetailedContentFromWip = this.fetchDetailedContentFromWip.bind(this);
-    this.handleChange = this.handleChange.bind(this);
-    this.sendButtonClickedEvent = this.sendButtonClickedEvent.bind(this);
-    this.initCurrentFieldValues = this.initCurrentFieldValues.bind(this);
-    this.fetchDefinitionsFromProps = this.fetchDefinitionsFromProps.bind(this);
-    this.setFetched = this.setFetched.bind(this);
     const getWipWorkbatch = this.props.getWipWorkbatch;
     const org = this.props.organization;
     getWipWorkbatch(org)
@@ -30,11 +23,11 @@ class WorkbatchDetails extends React.Component {
       .then(this.setFetched);
   }
 
-  setFetched() {
+  setFetched = () => {
     this.setState({fetched: true});
-  }
+  };
 
-  fetchStaticContentsFromWip() {
+  fetchStaticContentsFromWip = () => {
     const byIds = this.props.workBatchEntry.byIds;
     const arr = Object.values(byIds);
     let wipWorkbatch = arr[0];
@@ -42,16 +35,16 @@ class WorkbatchDetails extends React.Component {
       this.props.organization,
       wipWorkbatch.cls_full_name
     );
-  }
+  };
 
-  fetchDetailedContentFromWip() {
+  fetchDetailedContentFromWip = () => {
     const byIds = this.props.workBatchEntry.byIds;
     const arr = Object.values(byIds);
     let wipWorkbatch = arr[0];
     return this.props.getWorkBatchDetails(this.props.organization, wipWorkbatch.id);
-  }
+  };
 
-  fetchDefinitionsFromProps() {
+  fetchDefinitionsFromProps = () => {
     let workBatchDefinitionEntry = this.props.workBatchDefinitionEntry;
     if (!workBatchDefinitionEntry) {
       return;
@@ -73,13 +66,36 @@ class WorkbatchDetails extends React.Component {
         resolve
       );
     });
-  }
+  };
 
-  sendButtonClickedEvent(buttonEvent) {
+  getUpdatedWorkbatch = () => {
+    let {detailsId, byIds} = this.props.workBatchDetailsEntry;
+    let fetched_workbatch = byIds[detailsId];
+    let currentFieldValues = this.state.currentFieldValues;
+    let properties = Object.keys(currentFieldValues);
+    let updatedProperties = properties.reduce((previous, current) => {
+      let entry = {
+        value: currentFieldValues[current],
+      };
+      return {
+        ...previous,
+        [current]: entry,
+      };
+    }, {});
+    let mergedProperties = merge({}, fetched_workbatch.properties, updatedProperties);
+    return {
+      ...fetched_workbatch,
+      properties: mergedProperties,
+    };
+  };
+
+  sendButtonClickedEvent = (buttonEvent) => {
+    let updatedWorkbatch = this.getUpdatedWorkbatch();
+    this.props.updateWorkBatchDetails(this.props.organization, updatedWorkbatch);
     this.props.sendButtonClickedEvent(this.props.organization, buttonEvent);
-  }
+  };
 
-  render() {
+  render = () => {
     //TODO: merge this with files in the workBatchDetails folder
     if (
       this.props.workBatchDetailsEntry.loadingDetails ||
@@ -101,9 +117,9 @@ class WorkbatchDetails extends React.Component {
         workBatchId={workbatchId}
       />
     );
-  }
+  };
 
-  initCurrentFieldValues() {
+  initCurrentFieldValues = () => {
     let {detailsId, byIds} = this.props.workBatchDetailsEntry;
     if (!(detailsId in byIds)) {
       throw new Error('No matching entry for detailsId');
@@ -124,9 +140,9 @@ class WorkbatchDetails extends React.Component {
         resolve
       );
     });
-  }
+  };
 
-  handleChange(e) {
+  handleChange = (e) => {
     let {name, value} = e.target;
     this.setState((prevState) => {
       let {currentFieldValues} = {...prevState};
@@ -135,7 +151,7 @@ class WorkbatchDetails extends React.Component {
         currentFieldValues,
       };
     });
-  }
+  };
 }
 
 WorkbatchDetails.propTypes = {

--- a/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
@@ -46,17 +46,14 @@ class WorkbatchDetails extends React.Component {
 
   fetchDefinitionsFromProps = () => {
     let workBatchDefinitionEntry = this.props.workBatchDefinitionEntry;
-    if (!workBatchDefinitionEntry) {
-      return;
-    }
     let {byIds, detailsId} = workBatchDefinitionEntry;
-    if (!detailsId) {
-      return;
-    }
     let workDefinition = byIds[detailsId];
+    if (!workDefinition) {
+      throw new Error('Something went wrong when parsing static contents');
+    }
     let {fields, buttons, id} = workDefinition;
     if (!fields || !buttons || !id) {
-      return;
+      throw new Error('Something went wrong when parsing static contents');
     }
     return new Promise((resolve) => {
       this.setState(

--- a/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
@@ -204,6 +204,7 @@ export function getUpdatedWorkBatch(workBatchDetailsEntry, currentFieldValues) {
   let properties = Object.keys(currentFieldValues);
   let updatedProperties = properties.reduce((previous, current) => {
     let entry = {
+      name: current,
       value: currentFieldValues[current],
     };
     return {

--- a/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
@@ -66,12 +66,12 @@ class WorkbatchDetails extends React.Component {
       return;
     }
     return new Promise((resolve) => {
-      this.setState((prevState) => {
-        return {
-          ...prevState,
+      this.setState(
+        {
           workDefinition,
-        };
-      }, resolve);
+        },
+        resolve
+      );
     });
   }
 
@@ -117,12 +117,12 @@ class WorkbatchDetails extends React.Component {
       };
     }, {});
     return new Promise((resolve) => {
-      this.setState((prevState) => {
-        return {
-          ...prevState,
+      this.setState(
+        {
           currentFieldValues,
-        };
-      }, resolve);
+        },
+        resolve
+      );
     });
   }
 

--- a/tests/clims/api/endpoints/test_work_batch_details.py
+++ b/tests/clims/api/endpoints/test_work_batch_details.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
+import pytest
+import json
 from django.core.urlresolvers import reverse
+from rest_framework import status
 
 from sentry.testutils import APITestCase
 
@@ -31,6 +34,36 @@ class WorkBatchDetailsEndpointTest(APITestCase):
         assert response.data['id'] == workbatch.id
         assert response.data['name'] == 'my_workbatch'
         assert response.data['properties']['kit_type']['value'] == 'kit type value'
+
+    @pytest.mark.dev_edvard
+    def test_put__update_property(self):
+        # Arrange
+        workbatch = MyWorkbatchImplementation(name='my_workbatch')
+        workbatch.kit_type = 'kit type value'
+        workbatch.save()
+
+        url = reverse('clims-api-0-work-batch-details',
+                      args=(self.organization.name, workbatch.id))
+        self.login_as(self.user)
+        payload = {
+            'properties': {
+                'kit_type': {
+                    'value': 'updated kit type'
+                }
+            }
+        }
+
+        # Act
+        response = self.client.put(
+            path=url,
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK, response.data
+        fetched_workbatch = self.app.workbatches.get(id=workbatch.id)
+        assert fetched_workbatch.kit_type == 'updated kit type'
 
 
 class MyWorkbatchImplementation(WorkBatchBase):

--- a/tests/clims/api/serializers/models/test_extensible_property.py
+++ b/tests/clims/api/serializers/models/test_extensible_property.py
@@ -44,5 +44,5 @@ class ExtensiblePropertyTypeSerializerTestCase(TestCase):
         string_prop = self.create_string_prop(name, disp_name, value)
         serializer = ExtensiblePropertySerializer(string_prop)
         assert serializer.data['name'] == name
-        assert serializer.data['value'] == value
+        assert serializer.data['value'] == str(value)
         assert serializer.data['display_name'] == disp_name

--- a/tests/clims/api/serializers/models/test_extensible_property.py
+++ b/tests/clims/api/serializers/models/test_extensible_property.py
@@ -35,7 +35,6 @@ class ExtensiblePropertyTypeSerializerTestCase(TestCase):
         serializer = ExtensiblePropertySerializer(string_prop)
         assert serializer.data['name'] == name
         assert serializer.data['value'] == value
-        assert serializer.data['display_name'] == disp_name
 
     def test_can_serialize_extensible_property_simple_int_prop(self):
         name = "intprop"
@@ -45,4 +44,3 @@ class ExtensiblePropertyTypeSerializerTestCase(TestCase):
         serializer = ExtensiblePropertySerializer(string_prop)
         assert serializer.data['name'] == name
         assert serializer.data['value'] == str(value)
-        assert serializer.data['display_name'] == disp_name

--- a/tests/clims/api/serializers/models/test_work_batch_details.py
+++ b/tests/clims/api/serializers/models/test_work_batch_details.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+import io
+import pytest
+from rest_framework.parsers import JSONParser
 from sentry.testutils import TestCase
 
 from clims.api.serializers.models.work_batch_details import WorkBatchDetailsSerializer
@@ -21,6 +24,86 @@ class WorkBatchSerializerTest(TestCase):
         assert result.get('name') == 'Test1'
         properties = result.get('properties')
         assert properties['kit_type']['value'] == 'kit type value'
+
+    def test_can_instantiate_serializer__with_no_properties(self):
+        json = b'{"properties":null, "id":1,"name":"Test1"}'
+        stream = io.BytesIO(json)
+        data = JSONParser().parse(stream)
+        serializer = WorkBatchDetailsSerializer(data=data)
+        assert serializer.is_valid()
+
+    def test_can_update_workbatch_property__from_no_value(self):
+        data = {
+            'id': 1,
+            'name': 'Test1',
+            'properties': {
+                'kit_type': {'value': 'kit type value'},
+            }
+        }
+        workbatch = MyWorkbatchImplementation(name='my_workbatch')
+        workbatch.save()
+        serializer = WorkBatchDetailsSerializer(workbatch, data=data)
+        assert serializer.is_valid()
+        updated_workbatch = serializer.save()
+        assert updated_workbatch.kit_type == 'kit type value'
+
+    def test_can_update_workbatch_property__from_existing_value(self):
+        data = {
+            'id': 1,
+            'name': 'Test1',
+            'properties': {
+                'kit_type': {'value': 'kit type value'},
+            }
+        }
+        workbatch = MyWorkbatchImplementation(name='my_workbatch')
+        workbatch.kit_type = 'previous value'
+        workbatch.save()
+        serializer = WorkBatchDetailsSerializer(workbatch, data=data)
+        assert serializer.is_valid()
+        updated_workbatch = serializer.save()
+        assert updated_workbatch.kit_type == 'kit type value'
+
+    def test_can_update_workbatch_properties__with_properties_set_to_none(self):
+        data = {
+            'id': 1,
+            'name': 'Test1',
+            'properties': None
+        }
+        workbatch = MyWorkbatchImplementation(name='my_workbatch')
+        workbatch.save()
+        serializer = WorkBatchDetailsSerializer(workbatch, data=data)
+        assert serializer.is_valid()
+        updated_workbatch = serializer.save()
+        assert updated_workbatch.kit_type is None
+
+    def test_can_update_workbatch_properties__with_properties_set_to_empty(self):
+        data = {
+            'id': 1,
+            'name': 'Test1',
+            'properties': {}
+        }
+        workbatch = MyWorkbatchImplementation(name='my_workbatch')
+        workbatch.save()
+        serializer = WorkBatchDetailsSerializer(workbatch, data=data)
+        assert serializer.is_valid()
+        updated_workbatch = serializer.save()
+        assert updated_workbatch.kit_type is None
+
+    @pytest.mark.dev_edvard
+    def test_update_workbatch_properties__with_empty_dict__previous_values_dont_change(self):
+        # TODO: is this the intended behavour?
+        data = {
+            'id': 1,
+            'name': 'Test1',
+            'properties': {}
+        }
+        workbatch = MyWorkbatchImplementation(name='my_workbatch')
+        workbatch.kit_type = 'kit type value'
+        workbatch.save()
+        serializer = WorkBatchDetailsSerializer(workbatch, data=data)
+        assert serializer.is_valid()
+        updated_workbatch = serializer.save()
+        assert updated_workbatch.kit_type == 'kit type value'
 
 
 class MyWorkbatchImplementation(WorkBatchBase):

--- a/tests/js/spec/components/workBatchDetails.spec.jsx
+++ b/tests/js/spec/components/workBatchDetails.spec.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {resource} from 'app/redux/reducers/shared';
+import {getUpdatedWorkBatch} from 'app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails';
+
+describe('workbatch details', () => {
+  it('should merge updated fields with original workbatch', () => {
+    // Arrange
+    const originalWorkbatch = {
+      id: 1000,
+      properties: {
+        property1: {
+          id: 1,
+          name: 'property1',
+          value: 'orig value',
+        },
+        property2: {
+          id: 2,
+          name: 'property2',
+          value: 'orig value',
+        },
+      },
+    };
+    const initialState = {...resource.initialState};
+    const workBatchDetailsEntry = {
+      ...initialState,
+      detailsId: 1000,
+      byIds: {
+        ...initialState.byIds,
+        1000: {
+          ...originalWorkbatch,
+        },
+      },
+    };
+    const currentFieldValues = {
+      property1: 'new value',
+      property3: 'new value 3',
+    };
+
+    // Act
+    const updatedWorkBatch = getUpdatedWorkBatch(
+      workBatchDetailsEntry,
+      currentFieldValues
+    );
+
+    // Assert
+    const expectedMergedWorkbatch = {
+      id: 1000,
+      properties: {
+        property1: {
+          id: 1,
+          name: 'property1',
+          value: 'new value',
+        },
+        property2: {
+          id: 2,
+          name: 'property2',
+          value: 'orig value',
+        },
+        property3: {
+          value: 'new value 3',
+        },
+      },
+    };
+    expect(updatedWorkBatch).toEqual(expectedMergedWorkbatch);
+  });
+});

--- a/tests/js/spec/components/workBatchDetails.spec.jsx
+++ b/tests/js/spec/components/workBatchDetails.spec.jsx
@@ -9,12 +9,10 @@ describe('workbatch details', () => {
       id: 1000,
       properties: {
         property1: {
-          id: 1,
           name: 'property1',
           value: 'orig value',
         },
         property2: {
-          id: 2,
           name: 'property2',
           value: 'orig value',
         },
@@ -47,16 +45,15 @@ describe('workbatch details', () => {
       id: 1000,
       properties: {
         property1: {
-          id: 1,
           name: 'property1',
           value: 'new value',
         },
         property2: {
-          id: 2,
           name: 'property2',
           value: 'orig value',
         },
         property3: {
+          name: 'property3',
           value: 'new value 3',
         },
       },


### PR DESCRIPTION
Implement PUT action in workbatch details endpoint, and adjust the serializers for this call. All property fields in UI are here controlled components, with keystrokes captured in a local state. The PUT api call is triggered whenever the user clicks on any user configured button. My first objective here was just to make able to test the update. It's however probable that this call is going to stay there, because the workbatch properties are used within the extensible scripts. At the PUT api call, the local state is transferred to the redux state. 

I made a series of small refactorings in the workbatch details component, according to a PluralSight course I follow. 