### PR TITLE
clims-472, delete extensible field

### DIFF
--- a/src/clims/api/serializers/models/extensible_property.py
+++ b/src/clims/api/serializers/models/extensible_property.py
@@ -6,4 +6,4 @@ from rest_framework import serializers
 
 class ExtensiblePropertySerializer(serializers.Serializer):
     name = serializers.CharField(read_only=True)
-    value = serializers.CharField()
+    value = serializers.CharField(allow_null=True)

--- a/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetailsWaitingToBeMerged/workbatchDetails.jsx
@@ -199,7 +199,7 @@ export function getUpdatedWorkBatch(workBatchDetailsEntry, currentFieldValues) {
   let updatedProperties = properties.reduce((previous, current) => {
     let entry = {
       name: current,
-      value: currentFieldValues[current],
+      value: currentFieldValues[current] ? currentFieldValues[current] : null,
     };
     return {
       ...previous,

--- a/tests/clims/api/endpoints/test_substances.py
+++ b/tests/clims/api/endpoints/test_substances.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import random
 import json
-import pytest
 
 from django.core.urlresolvers import reverse
 
@@ -143,7 +142,6 @@ class SubstancesTest(APITestCase):
 
         asserts(stone1, data_by_id[stone1.id])
 
-    @pytest.mark.dev_edvard
     def test_filter_substances_on_container(self):
         # Arrange
         container = self.create_container(GemstoneContainer, name='mycontainer')

--- a/tests/clims/api/endpoints/test_work_batch.py
+++ b/tests/clims/api/endpoints/test_work_batch.py
@@ -11,6 +11,7 @@ from clims.plugins.demo.dnaseq.workflows.sequence import SequenceSimple
 from clims.services.workbatch import WorkBatchBase
 from clims.api.endpoints.work_batch import WorkBatchEndpoint
 from clims.api.endpoints.work_units import WorkUnitsEndpoint
+from clims.services.extensible import TextField
 
 
 class WorkBatchEndpointTest(APITestCase):
@@ -83,4 +84,4 @@ class WorkBatchEndpointTest(APITestCase):
 
 
 class MyWorkbatchImplementation(WorkBatchBase):
-    pass
+    comment = TextField()

--- a/tests/clims/api/endpoints/test_work_batch_details.py
+++ b/tests/clims/api/endpoints/test_work_batch_details.py
@@ -35,7 +35,6 @@ class WorkBatchDetailsEndpointTest(APITestCase):
         assert response.data['name'] == 'my_workbatch'
         assert response.data['properties']['kit_type']['value'] == 'kit type value'
 
-    @pytest.mark.dev_edvard
     def test_put__update_property(self):
         # Arrange
         workbatch = MyWorkbatchImplementation(name='my_workbatch')
@@ -64,6 +63,36 @@ class WorkBatchDetailsEndpointTest(APITestCase):
         assert response.status_code == status.HTTP_200_OK, response.data
         fetched_workbatch = self.app.workbatches.get(id=workbatch.id)
         assert fetched_workbatch.kit_type == 'updated kit type'
+
+    @pytest.mark.dev_edvard
+    def test_initialize_property__then_delete_it(self):
+        # Arrange
+        workbatch = MyWorkbatchImplementation(name='my_workbatch')
+        workbatch.kit_type = 'kit type value'
+        workbatch.save()
+
+        url = reverse('clims-api-0-work-batch-details',
+                      args=(self.organization.name, workbatch.id))
+        self.login_as(self.user)
+        payload = {
+            'properties': {
+                'kit_type': {
+                    'value': None
+                }
+            }
+        }
+
+        # Act
+        response = self.client.put(
+            path=url,
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK, response.data
+        fetched_workbatch = self.app.workbatches.get(id=workbatch.id)
+        assert fetched_workbatch.kit_type is None
 
 
 class MyWorkbatchImplementation(WorkBatchBase):

--- a/tests/clims/models/test_substance.py
+++ b/tests/clims/models/test_substance.py
@@ -123,12 +123,27 @@ class SubstancePropertiesTestCase(TestCase):
                           cool=cool,
                           erudite=None)
 
+    @pytest.mark.dev_edvard
+    def test__set_text_property__then_delete_it(self):
+        name = "sample-{}".format(random.randint(1, 1000000))
+
+        sample = ExampleSample(name=name)
+        sample.mox_feeling = 'delirious'
+        sample.save()
+        original_sample_version = sample.version
+
+        sample.mox_feeling = None
+        sample.save()
+
+        fetched_sample = self.app.substances.get(name=sample.name)
+        assert fetched_sample.mox_feeling is None
+        assert sample.version == original_sample_version + 1
+
 
 class TestSubstance(SubstanceTestCase):
     def setUp(self):
         self.has_context()
 
-    @pytest.mark.dev_edvard
     def test_gemstone_inheritance(self):
         self.register_extensible(InheritedSample)
         sample = InheritedSample(name='sample1')

--- a/tests/js/spec/components/workBatchDetails.spec.jsx
+++ b/tests/js/spec/components/workBatchDetails.spec.jsx
@@ -54,4 +54,56 @@ describe('workbatch details', () => {
     };
     expect(updatedWorkBatch).toEqual(expectedMergedWorkbatch);
   });
+
+  it('should convert blank values to null when merging fields', () => {
+    // Arrange
+    const originalWorkbatch = {
+      id: 1000,
+      properties: {
+        property1: {
+          name: 'property1',
+          value: 'orig value',
+        },
+        property2: {
+          name: 'property2',
+          value: 'orig value',
+        },
+      },
+    };
+    const initialState = {...resource.initialState};
+    const workBatchDetailsEntry = {
+      ...initialState,
+      entry: originalWorkbatch,
+    };
+    const currentFieldValues = {
+      property1: 'new value',
+      property3: '',
+    };
+
+    // Act
+    const updatedWorkBatch = getUpdatedWorkBatch(
+      workBatchDetailsEntry,
+      currentFieldValues
+    );
+
+    // Assert
+    const expectedMergedWorkbatch = {
+      id: 1000,
+      properties: {
+        property1: {
+          name: 'property1',
+          value: 'new value',
+        },
+        property2: {
+          name: 'property2',
+          value: 'orig value',
+        },
+        property3: {
+          name: 'property3',
+          value: null,
+        },
+      },
+    };
+    expect(updatedWorkBatch).toEqual(expectedMergedWorkbatch);
+  });
 });


### PR DESCRIPTION
Purpose:
To be able to delete an extensible field value that has previously been initialized with a value. 