### PR TITLE
clims-474 qc analyze script

### DIFF
--- a/src/clims/api/serializers/models/work_batch_details_definition.py
+++ b/src/clims/api/serializers/models/work_batch_details_definition.py
@@ -25,3 +25,4 @@ class WorkBatchDetailsDefinitionSerializer(serializers.Serializer):
     name = serializers.CharField(read_only=True)
     buttons = serializers.ListField(child=ButtonField(), read_only=True)
     fields = serializers.ListField(child=FieldPropertyField(), read_only=True)
+    criteria_descriptions = serializers.ListField(read_only=True)

--- a/src/clims/configuration/hooks.py
+++ b/src/clims/configuration/hooks.py
@@ -11,3 +11,8 @@ def button(button_text):
         setattr(fn, HOOK_TAG, button_text)
         return fn
     return button_decorator
+
+
+def criteria(fn):
+    setattr(fn, HOOK_TYPE, 'criteria')
+    return fn

--- a/src/clims/configuration/hooks.py
+++ b/src/clims/configuration/hooks.py
@@ -13,6 +13,9 @@ def button(button_text):
     return button_decorator
 
 
-def criteria(fn):
-    setattr(fn, HOOK_TYPE, 'criteria')
-    return fn
+def criteria(description):
+    def criteria_decorator(fn):
+        setattr(fn, HOOK_TYPE, 'criteria')
+        setattr(fn, HOOK_TAG, description)
+        return fn
+    return criteria_decorator

--- a/src/clims/services/extensible.py
+++ b/src/clims/services/extensible.py
@@ -688,7 +688,7 @@ class IntField(ExtensibleBaseField):
 
 class BoolField(ExtensibleBaseField):
     def validate(self, prop_type, value):
-        if not isinstance(value, bool):
+        if not isinstance(value, bool) and value is not None:
             raise ExtensibleTypeValidationError(
                 "Value can not be interpreted as bool")
 

--- a/src/clims/services/workbatch.py
+++ b/src/clims/services/workbatch.py
@@ -46,6 +46,8 @@ class WorkBatchBase(ExtensibleBase):
 
     def __init__(self, **kwargs):
         super(WorkBatchBase, self).__init__(**kwargs)
+        self.parent_substances = None
+        self.child_substances = None
         self._update_queue = list()
 
     def stage_update(self, obj):
@@ -54,6 +56,13 @@ class WorkBatchBase(ExtensibleBase):
     def commit(self):
         for queued_object in self._update_queue:
             queued_object.save()
+
+    def output_plates(self):
+        ret_dict = {
+            s.location.container.id: s.location.container
+            for s in self.child_substances if s.location
+        }
+        return [ret_dict[id] for id in ret_dict]
 
     @classmethod
     def cls_full_name(cls):

--- a/src/clims/services/workbatch.py
+++ b/src/clims/services/workbatch.py
@@ -86,12 +86,17 @@ class WorkBatchBase(ExtensibleBase):
             buttons.append(b)
         return buttons
 
+    @classmethod
+    def criterias(cls):
+        return [c for c in cls._get_hooks_for('criteria')]
+
+    @classmethod
+    def criteria_descriptions(cls):
+        return [c.hook_tag for c in cls.criterias()]
+
     def is_satisfied_by(self, substance):
-        criterias = list()
-        for hook in self.__class__._get_hooks_for('criteria'):
-            criterias.append(hook.callable)
-        for c in criterias:
-            if not c(self, substance):
+        for c in self.__class__.criterias():
+            if not c.callable(self, substance):
                 return False
         return True
 

--- a/src/clims/services/workbatch.py
+++ b/src/clims/services/workbatch.py
@@ -44,6 +44,17 @@ class WorkBatchBase(ExtensibleBase):
     WrappedArchetype = WorkBatch
     WrappedVersion = WorkBatchVersion
 
+    def __init__(self, **kwargs):
+        super(WorkBatchBase, self).__init__(**kwargs)
+        self._update_queue = list()
+
+    def stage_update(self, obj):
+        self._update_queue.append(obj)
+
+    def commit(self):
+        for queued_object in self._update_queue:
+            queued_object.save()
+
     @classmethod
     def cls_full_name(cls):
         # Corresponds to 'full_name' in serializer

--- a/tests/clims/api/serializers/models/test_work_batch_details_definition.py
+++ b/tests/clims/api/serializers/models/test_work_batch_details_definition.py
@@ -4,7 +4,7 @@ from sentry.testutils import TestCase
 
 from clims.api.serializers.models.work_batch_details_definition import WorkBatchDetailsDefinitionSerializer
 from clims.services.workbatch import WorkBatchBase
-from clims.configuration.hooks import button
+from clims.configuration.hooks import button, criteria
 from clims.services.extensible import TextField
 
 
@@ -22,10 +22,15 @@ class WorkBatchDetailsDefintionSerializerTest(TestCase):
         assert result.get('fields') == [
             {'type': 'string', 'caption': 'Machine entry', 'prop_name': 'machine_entry'}
         ]
+        assert result.get('criteria_descriptions') == ['conc >= 5']
 
 
 class MyFancyStep(WorkBatchBase):
     machine_entry = TextField(display_name="Machine entry")
+
+    @criteria("conc >= 5")
+    def qc_criteria(self, sample):
+        return sample.conc >= 5
 
     @button('My submit button')
     def on_button_click1(self):


### PR DESCRIPTION
Purpose:
Prepare commonlims framework to be able to handle criteria in workbatches. criteria is added by a technical user at configuration for a step, and is used for validating qc on each sample in workbatch. 

Implementation:
In commonlims-snpseq, analyzing qc criteria could not be imported directly from clarity-ext, since this script is implemented in the lab-logic tool. Instead there is a "native" analyze qc script in snpseq. Because of that, I here added an update queue in workbatch, so that we here can follow the two-step pattern of updating samples, which is 1) put sample in a updated queue when executing script, 2) when script has finished without errors, perform a commit and save to db. 