### PR TITLE
clims 493, Show workbatch details with a non-mock workbatch instance

### DIFF
--- a/src/sentry/static/sentry/app/climsTypes.jsx
+++ b/src/sentry/static/sentry/app/climsTypes.jsx
@@ -34,17 +34,17 @@ export const Organization = PropTypes.shape({
 export const WorkBatch = PropTypes.shape({
   id: PropTypes.number.isRequired,
   name: PropTypes.string.isRequired,
-  processDefinitionKey: PropTypes.string.isRequired,
+  processDefinitionKey: PropTypes.string,
   created_at: PropTypes.string.isRequired, // TODO: Map to date
   updated_at: PropTypes.string.isRequired,
-  num_comments: PropTypes.number.isRequired,
-  status: PropTypes.string.isRequired,
-  subtasks: PropTypes.array.isRequired, // TODO: Describe
+  num_comments: PropTypes.number,
+  status: PropTypes.string,
+  subtasks: PropTypes.array, // TODO: Describe
   transitions: PropTypes.array.isRequired,
   source: PropTypes.shape({
     substances: PropTypes.array, // TODO: describe
     containers: PropTypes.array,
-  }).isRequired,
+  }),
   target: PropTypes.shape({
     substances: PropTypes.array,
     containers: PropTypes.array,

--- a/src/sentry/static/sentry/app/redux/actions/sharedEntry.js
+++ b/src/sentry/static/sentry/app/redux/actions/sharedEntry.js
@@ -77,51 +77,6 @@ const acGet = (resource, urlTemplate) => {
   };
 };
 
-// Create actions
-const acCreateRequest = (resource) =>
-  makeActionCreator(`CREATE_${resource}_REQUEST`, 'entry');
-
-const acCreateSuccess = (resource) =>
-  makeActionCreator(`CREATE_${resource}_SUCCESS`, 'entry');
-
-const acCreateFailure = (resource) =>
-  makeActionCreator(`CREATE_${resource}_FAILURE`, 'statusCode', 'message');
-
-const acCreate = (resource, urlTemplate) => {
-  return (org, data, onSuccess) => (dispatch) => {
-    dispatch(acCreateRequest(resource)(data));
-
-    const url = urlTemplate.replace('{org}', org.slug);
-    // use client that sentry is using
-    const api = new Client(); // TODO: use axios (must send same headers as Client does).
-    api.request(url, {
-      method: 'POST',
-      data,
-      success: (response) => {
-        dispatch(acCreateSuccess(resource)(data));
-
-        // TODO: This is to handle redirects. There is perhaps a better
-        // pattern for this using redux only?
-        if (onSuccess) {
-          onSuccess(response);
-        }
-      },
-      error: (err) => {
-        const message = getErrorMessage(err);
-        dispatch(acCreateFailure(resource)(err.status, message));
-      },
-    });
-    // TODO: uncomment this when clims-465 is completed
-    // return axios
-    //   .post(url, data)
-    //   .then(() => dispatch(acCreateSuccess(resource)(data)))
-    //   .catch((response) => {
-    //     const message = getErrorMessage(response.request);
-    //     dispatch(acCreateFailure(resource)(response.request.status, message));
-    //   });
-  };
-};
-
 function getErrorMessage(err) {
   return `(${err.statusText}) ${err.responseText}`;
 }
@@ -135,10 +90,6 @@ export const entryActionCreators = {
   acUpdateRequest,
   acUpdateSuccess,
   acUpdateFailure,
-  acCreate,
-  acCreateRequest,
-  acCreateSuccess,
-  acCreateFailure,
 };
 
 // Creates all actions required for a regular resource
@@ -155,11 +106,5 @@ export const makeResourceActions = (resourceName, entryUrl) => {
     updateRequest: acUpdateRequest(resourceName),
     updateSuccess: acUpdateSuccess(resourceName),
     updateFailure: acUpdateFailure(resourceName),
-
-    // Create entries
-    create: acCreate(resourceName, entryUrl),
-    createRequest: acCreateRequest(resourceName),
-    createSuccess: acCreateSuccess(resourceName),
-    createFailure: acCreateFailure(resourceName),
   };
 };

--- a/src/sentry/static/sentry/app/redux/actions/workBatchDetails.js
+++ b/src/sentry/static/sentry/app/redux/actions/workBatchDetails.js
@@ -1,8 +1,8 @@
 import {makeResourceActions} from 'app/redux/actions/sharedEntry';
 
-export const RESOURCE_NAME = 'WORK_BATCH';
+export const RESOURCE_NAME = 'WORK_BATCH_DETAILS';
 
 export const workBatchActions = makeResourceActions(
   RESOURCE_NAME,
-  '/api/0/organizations/{org}/work-batches/'
+  '/api/0/organizations/{org}/work-batch-details/{id}'
 );

--- a/src/sentry/static/sentry/app/redux/reducers/sharedEntry.js
+++ b/src/sentry/static/sentry/app/redux/reducers/sharedEntry.js
@@ -46,29 +46,6 @@ export function getEntryFailure(state, action) {
   };
 }
 
-export function createEntryRequest(state, action) {
-  return {
-    ...state,
-    creating: true,
-  };
-}
-
-export function createEntrySuccess(state, action) {
-  return {
-    ...state,
-    creating: false,
-    entry: action.entry,
-  };
-}
-
-export function createEntryFailure(state, action) {
-  return {
-    ...state,
-    creating: false,
-    errorMessage: action.message,
-  };
-}
-
 const createResourceReducer = (resource, initialState) => (
   state = initialState,
   action
@@ -86,12 +63,6 @@ const createResourceReducer = (resource, initialState) => (
       return updateEntrySuccess(state, action);
     case `UPDATE_${resource}_FAILURE`:
       return updateEntryFailure(state, action);
-    case `CREATE_${resource}_REQUEST`:
-      return createEntryRequest(state, action);
-    case `CREATE_${resource}_SUCCESS`:
-      return createEntrySuccess(state, action);
-    case `CREATE_${resource}_FAILURE`:
-      return createEntryFailure(state, action);
     default:
       return state;
   }
@@ -103,7 +74,6 @@ export const entry = {
     loadingDetails: false,
     updating: false,
     entry: null,
-    creating: false,
   },
 
   getEntryRequest,
@@ -112,9 +82,6 @@ export const entry = {
   updateEntryRequest,
   updateEntrySuccess,
   updateEntryFailure,
-  createEntryRequest,
-  createEntrySuccess,
-  createEntryFailure,
 };
 
 export const resource = {

--- a/src/sentry/static/sentry/app/redux/reducers/sharedList.js
+++ b/src/sentry/static/sentry/app/redux/reducers/sharedList.js
@@ -100,6 +100,7 @@ export function createEntrySuccess(state, action) {
     ...state,
     creating: false,
     createdEntry: action.entry,
+    byIds: merge({}, state.byIds, {[action.entry.id]: action.entry}),
   };
 }
 

--- a/src/sentry/static/sentry/app/redux/reducers/sharedList.js
+++ b/src/sentry/static/sentry/app/redux/reducers/sharedList.js
@@ -88,6 +88,29 @@ export function getListFailure(state, action) {
   };
 }
 
+export function createEntryRequest(state, action) {
+  return {
+    ...state,
+    creating: true,
+  };
+}
+
+export function createEntrySuccess(state, action) {
+  return {
+    ...state,
+    creating: false,
+    createdEntry: action.entry,
+  };
+}
+
+export function createEntryFailure(state, action) {
+  return {
+    ...state,
+    creating: false,
+    errorMessage: action.message,
+  };
+}
+
 const createResourceReducer = (resource, initialState) => (
   state = initialState,
   action
@@ -103,6 +126,12 @@ const createResourceReducer = (resource, initialState) => (
       return selectSingle(state, action);
     case `SELECT_PAGE_OF_${resource}`:
       return selectAll(state, action);
+    case `CREATE_${resource}_REQUEST`:
+      return createEntryRequest(state, action);
+    case `CREATE_${resource}_SUCCESS`:
+      return createEntrySuccess(state, action);
+    case `CREATE_${resource}_FAILURE`:
+      return createEntryFailure(state, action);
     default:
       return state;
   }
@@ -112,7 +141,9 @@ export const list = {
   // State we require for following a list protocol
   initialState: {
     loading: false,
+    creating: false,
     errorMessage: null,
+    createdEntry: null,
     byIds: {},
     listViewState: {
       allVisibleSelected: false,
@@ -133,6 +164,9 @@ export const list = {
   getListRequest,
   getListSuccess,
   getListFailure,
+  createEntryRequest,
+  createEntrySuccess,
+  createEntryFailure,
 };
 
 // A resource follows both the list and entry protocols

--- a/src/sentry/static/sentry/app/views/availableWorkDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/availableWorkDetails/index.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import withOrganization from 'app/utils/withOrganization';
 import WorkUnits from './workUnits';
 import {connect} from 'react-redux';
-import {workBatchActions} from 'app/redux/actions/workBatchDetails';
+import {workBatchActions} from 'app/redux/actions/workBatch';
 import {workDefinitionActions} from 'app/redux/actions/workDefinition';
 import {availableWorkUnitActions} from 'app/redux/actions/availableWorkUnit';
 import ClimsTypes from 'app/climsTypes';

--- a/src/sentry/static/sentry/app/views/workBatchDetails/shared/actions.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetails/shared/actions.jsx
@@ -96,7 +96,9 @@ const WorkBatchActionsComponent = createReactClass({
   displayName: 'WorkBatchActions',
 
   propTypes: {
-    group: SentryTypes.Group.isRequired,
+    group: PropTypes.shape({
+      id: PropTypes.number.isRequired,
+    }),
   },
 
   mixins: [ApiMixin, OrganizationState],

--- a/src/sentry/static/sentry/app/views/workBatchDetails/shared/seenBy.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetails/shared/seenBy.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import moment from 'moment';
 import _ from 'lodash';
 import styled from 'react-emotion';
@@ -12,7 +13,9 @@ import {t} from 'app/locale';
 
 export default class GroupSeenBy extends React.Component {
   static propTypes = {
-    group: SentryTypes.Group.isRequired,
+    group: PropTypes.shape({
+      id: PropTypes.number.isRequired,
+    }),
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/workBatchDetails/shared/workBatchDetails.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetails/shared/workBatchDetails.jsx
@@ -6,7 +6,7 @@ import DocumentTitle from 'react-document-title';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import ClimsTypes from 'app/climsTypes';
 import withOrganization from 'app/utils/withOrganization';
-import {getWorkBatchDetails} from 'app/redux/actions/workBatchDetails_old';
+import {getWorkBatchDetails} from 'app/redux/actions/workBatchDetails';
 
 import WorkBatchDetailsFields from 'app/views/workBatchDetails/shared/workBatchFields';
 import WorkBatchDetailsFiles from 'app/views/workBatchDetails/shared/workBatchFiles';

--- a/src/sentry/static/sentry/app/views/workBatchDetails/shared/workBatchDetails.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetails/shared/workBatchDetails.jsx
@@ -6,7 +6,7 @@ import DocumentTitle from 'react-document-title';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import ClimsTypes from 'app/climsTypes';
 import withOrganization from 'app/utils/withOrganization';
-import {getWorkBatchDetails} from 'app/redux/actions/workBatchDetails';
+import {workBatchActions} from 'app/redux/actions/workBatchDetails';
 
 import WorkBatchDetailsFields from 'app/views/workBatchDetails/shared/workBatchFields';
 import WorkBatchDetailsFiles from 'app/views/workBatchDetails/shared/workBatchFiles';
@@ -124,10 +124,13 @@ WorkBatchDetailsContainer.propTypes = {
   getWorkBatchDetails: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = (state) => state.workBatchDetails;
+const mapStateToProps = (state) => ({
+  workBatchDetails: state.workBatchDetails,
+  workBatch: state.workBatchDetailsEntry.entry,
+});
 
 const mapDispatchToProps = (dispatch) => ({
-  getWorkBatchDetails: (org, id) => dispatch(getWorkBatchDetails(org, id)),
+  getWorkBatchDetails: (org, id) => dispatch(workBatchActions.get(org, id)),
 });
 
 export default withOrganization(

--- a/src/sentry/static/sentry/app/views/workBatchDetails/shared/workBatchDetails.jsx
+++ b/src/sentry/static/sentry/app/views/workBatchDetails/shared/workBatchDetails.jsx
@@ -120,7 +120,6 @@ TodoItem.propTypes = {
 };
 
 WorkBatchDetailsContainer.propTypes = {
-  workBatch: ClimsTypes.WorkBatch.isRequired,
   loading: PropTypes.bool.isRequired,
   getWorkBatchDetails: PropTypes.func.isRequired,
 };

--- a/tests/clims/api/endpoints/test_work_batch.py
+++ b/tests/clims/api/endpoints/test_work_batch.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 import json
-
+import pytest
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase

--- a/tests/clims/api/endpoints/test_work_batch.py
+++ b/tests/clims/api/endpoints/test_work_batch.py
@@ -47,6 +47,7 @@ class WorkBatchEndpointTest(APITestCase):
         assert response.data[0]['id'] == workbatch.id
         assert response.data[0]['name'] == 'my_workbatch'
 
+    @pytest.mark.dev_edvard
     def test_post(self):
         # TODO: Fix this test, or an equivalent one.
         self.login_as(self.user)

--- a/tests/js/spec/redux/reducers/sharedEntry.spec.js
+++ b/tests/js/spec/redux/reducers/sharedEntry.spec.js
@@ -103,39 +103,4 @@ describe('shared resource reducer', () => {
     };
     expect(failedState).toEqual(expectedState);
   });
-
-  it('has expected state when requesting an entry to be created', () => {
-    const successState = {
-      ...initialStateEntry,
-      creating: true,
-      entry: {id: '1'},
-    };
-    const createEntryRequestState = reducerEntry(
-      successState,
-      actions.createRequest({id: '1'})
-    );
-    expect(createEntryRequestState).toEqual({
-      ...successState,
-    });
-  });
-
-  it('has expected state when requesting an entry has successfully been created', () => {
-    const newItem = {
-      id: '3',
-      name: 'entry3',
-    };
-    const createEntryRequestState = reducerEntry(
-      {...initialStateEntry},
-      actions.createRequest(newItem)
-    );
-    const createEntrySuccessState = reducerEntry(
-      createEntryRequestState,
-      actions.createSuccess(newItem)
-    );
-
-    expect(createEntrySuccessState).toEqual({
-      ...initialStateEntry,
-      entry: newItem,
-    });
-  });
 });

--- a/tests/js/spec/redux/reducers/sharedList.spec.js
+++ b/tests/js/spec/redux/reducers/sharedList.spec.js
@@ -5,10 +5,6 @@ import {makeResourceActions} from 'app/redux/actions/sharedList';
 const RESOURCE_NAME = 'SOME_RESOURCE';
 
 // Tests the shared functionality of resource reducers
-const initialStateEntry = {
-  ...resource.initialState,
-};
-
 const initialStateList = {
   ...resource.initialState,
 };
@@ -155,7 +151,7 @@ describe('shared resource reducer', () => {
 
   it('has expected state when requesting an entry to be created', () => {
     const successState = {
-      ...initialStateEntry,
+      ...initialStateList,
       creating: true,
       entry: {id: '1'},
     };
@@ -174,7 +170,7 @@ describe('shared resource reducer', () => {
       name: 'entry3',
     };
     const createEntryRequestState = reducerList(
-      {...initialStateEntry},
+      {...initialStateList},
       actions.createRequest(newItem)
     );
     const createEntrySuccessState = reducerList(
@@ -183,8 +179,9 @@ describe('shared resource reducer', () => {
     );
 
     expect(createEntrySuccessState).toEqual({
-      ...initialStateEntry,
+      ...initialStateList,
       createdEntry: newItem,
+      byIds: {'3': newItem},
     });
   });
 });

--- a/tests/js/spec/redux/reducers/sharedList.spec.js
+++ b/tests/js/spec/redux/reducers/sharedList.spec.js
@@ -43,6 +43,8 @@ describe('shared resource reducer', () => {
     );
     expect(requestedState).toEqual({
       loading: true,
+      creating: false,
+      createdEntry: null,
       errorMessage: null,
       byIds: {},
       listViewState: {
@@ -60,6 +62,8 @@ describe('shared resource reducer', () => {
     const successState = createGetListSuccessState();
     expect(successState).toEqual({
       loading: false,
+      creating: false,
+      createdEntry: null,
       errorMessage: null,
       byIds: {'1': {id: '1', name: 'entry1'}, '2': {id: '2', name: 'entry2'}},
       listViewState: {
@@ -134,6 +138,8 @@ describe('shared resource reducer', () => {
     );
     expect(failedState).toEqual({
       loading: false,
+      creating: false,
+      createdEntry: null,
       errorMessage: 'some error',
       byIds: {},
       listViewState: {
@@ -144,6 +150,41 @@ describe('shared resource reducer', () => {
         selectedIds: new Set(),
         pagination: {pageLinks: null, cursor: 'cursor'},
       },
+    });
+  });
+
+  it('has expected state when requesting an entry to be created', () => {
+    const successState = {
+      ...initialStateEntry,
+      creating: true,
+      entry: {id: '1'},
+    };
+    const createEntryRequestState = reducerList(
+      successState,
+      actions.createRequest({id: '1'})
+    );
+    expect(createEntryRequestState).toEqual({
+      ...successState,
+    });
+  });
+
+  it('has expected state when requesting an entry has successfully been created', () => {
+    const newItem = {
+      id: '3',
+      name: 'entry3',
+    };
+    const createEntryRequestState = reducerList(
+      {...initialStateEntry},
+      actions.createRequest(newItem)
+    );
+    const createEntrySuccessState = reducerList(
+      createEntryRequestState,
+      actions.createSuccess(newItem)
+    );
+
+    expect(createEntrySuccessState).toEqual({
+      ...initialStateEntry,
+      createdEntry: newItem,
     });
   });
 });

--- a/tests/js/spec/redux/reducers/workDefinition.spec.js
+++ b/tests/js/spec/redux/reducers/workDefinition.spec.js
@@ -10,7 +10,6 @@ describe('workDefinition reducer, entry protocol', () => {
     );
     const expected = {
       loadingDetails: true,
-      creating: false,
       entry: null,
       updating: false,
     };
@@ -28,7 +27,6 @@ describe('workDefinition reducer, entry protocol', () => {
     const expected = {
       loadingDetails: false,
       entry: entry,
-      creating: false,
       updating: false,
     };
     expect(succeeded).toEqual(expected);


### PR DESCRIPTION
Purpose:
Show workbatch details page with data fetched from db. Here, I have moved the ac create entries in the shared entry reducer to the shared list reducer. I wanted to send in this PR rather quickly, because I suspect this change will affect you other guys in the project. 
